### PR TITLE
chore: Disable automatic Claude PR code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,5 +25,3 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           pr_number: ${{ inputs.pr_number }}
-          trigger_phrase: ''
-          review_on_open: false


### PR DESCRIPTION
Add .github/claude.json configuration to make Claude code reviews
manual instead of automatic on pull requests.