### PR TITLE
fix: Make Weekly Timesheet usable on mobile devices

### DIFF
--- a/src/components/timer/TimerDisplay.tsx
+++ b/src/components/timer/TimerDisplay.tsx
@@ -41,31 +41,31 @@ export function TimerDisplay({ onStartTimer }: TimerDisplayProps) {
   }
 
   return (
-    <div className="flex items-center gap-4 rounded-xl border border-dark-700 bg-dark-800 p-4 shadow-lg">
+    <div className="flex items-center gap-2 rounded-xl border border-dark-700 bg-dark-800 p-3 shadow-lg sm:gap-4 sm:p-4">
       {/* Timer Info */}
-      <div className="flex-1">
+      <div className="min-w-0 flex-1">
         <div className="mb-1 flex items-center gap-2">
           {currentProject && (
             <div
-              className="h-3 w-3 rounded-full"
+              className="h-3 w-3 shrink-0 rounded-full"
               style={{ backgroundColor: currentProject.color }}
             />
           )}
-          <span className="font-medium text-white">
+          <span className="truncate font-medium text-white">
             {currentProject?.name || 'Unknown Project'}
           </span>
         </div>
-        <p className="text-sm text-dark-400">{currentTask?.name || 'Unknown Task'}</p>
+        <p className="truncate text-sm text-dark-400">{currentTask?.name || 'Unknown Task'}</p>
         {timer.notes && <p className="truncate text-sm text-dark-500">{timer.notes}</p>}
       </div>
 
       {/* Timer Display */}
-      <div className="font-mono text-2xl font-bold tabular-nums text-knowall-green">
+      <div className="shrink-0 font-mono text-xl font-bold tabular-nums text-knowall-green sm:text-2xl">
         {formatDuration(timer.elapsedSeconds)}
       </div>
 
       {/* Stop Button */}
-      <Button onClick={handleStop} variant="danger" size="icon" className="rounded-full">
+      <Button onClick={handleStop} variant="danger" size="icon" className="shrink-0 rounded-full">
         <StopIcon className="h-5 w-5" />
         <span className="sr-only">Stop timer</span>
       </Button>

--- a/src/components/timesheet/TimeEntryCell.tsx
+++ b/src/components/timesheet/TimeEntryCell.tsx
@@ -39,7 +39,7 @@ export function TimeEntryCell({
   return (
     <div
       className={cn(
-        'min-h-[120px] border-r border-dark-700 p-2 transition-colors',
+        'min-h-[100px] border-r border-dark-700 p-1.5 transition-colors last:border-r-0 sm:min-h-[120px] sm:p-2',
         isToday ? 'bg-knowall-green/5' : 'bg-dark-800',
         isHovered && 'bg-dark-700/50'
       )}

--- a/src/components/timesheet/WeeklyTimesheet.tsx
+++ b/src/components/timesheet/WeeklyTimesheet.tsx
@@ -76,7 +76,7 @@ export function WeeklyTimesheet() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <WeekNavigation
           currentWeekStart={currentWeekStart}
           onPrevious={() => navigateToWeek('prev')}
@@ -86,8 +86,9 @@ export function WeeklyTimesheet() {
 
         <div className="flex items-center gap-3">
           <Button variant="outline" size="sm" onClick={handleCopyPreviousWeek} disabled={isLoading}>
-            <DocumentDuplicateIcon className="mr-2 h-4 w-4" />
-            Copy previous week
+            <DocumentDuplicateIcon className="h-4 w-4 sm:mr-2" />
+            <span className="hidden sm:inline">Copy previous week</span>
+            <span className="sm:hidden">Copy week</span>
           </Button>
         </div>
       </div>
@@ -106,56 +107,69 @@ export function WeeklyTimesheet() {
 
       {/* Timesheet Grid */}
       <Card variant="bordered" className="overflow-hidden">
-        {/* Day Headers */}
-        <div className="grid grid-cols-7 border-b border-dark-700 bg-dark-900">
-          {weekDays.map((day) => {
-            const isToday = isDayToday(day);
-            return (
-              <div
-                key={day.toISOString()}
-                className={`border-r border-dark-700 p-3 text-center last:border-r-0 ${
-                  isToday ? 'bg-knowall-green/10' : ''
-                }`}
-              >
-                <p className="text-xs font-medium uppercase text-dark-400">{format(day, 'EEE')}</p>
-                <p
-                  className={`text-lg font-semibold ${
-                    isToday ? 'text-knowall-green' : 'text-white'
-                  }`}
-                >
-                  {format(day, 'd')}
-                </p>
-              </div>
-            );
-          })}
+        {/* Mobile scroll hint */}
+        <div className="flex items-center justify-end gap-2 border-b border-dark-700 bg-dark-900/50 px-3 py-1.5 text-xs text-dark-400 sm:hidden">
+          <span>Swipe to view week</span>
+          <span>→</span>
         </div>
 
-        {/* Entries Grid */}
-        {isLoading ? (
-          <div className="flex h-64 items-center justify-center">
-            <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-knowall-green"></div>
-          </div>
-        ) : (
-          <div className="grid grid-cols-7">
-            {weekDays.map((day) => {
-              const dateStr = formatDate(day);
-              const dayEntries = getEntriesForDay(dateStr);
-              const isToday = isDayToday(day);
+        {/* Scrollable container for mobile */}
+        <div className="overflow-x-auto">
+          <div className="min-w-[640px]">
+            {/* Day Headers */}
+            <div className="grid grid-cols-7 border-b border-dark-700 bg-dark-900">
+              {weekDays.map((day) => {
+                const isToday = isDayToday(day);
+                return (
+                  <div
+                    key={day.toISOString()}
+                    className={`border-r border-dark-700 p-2 text-center last:border-r-0 sm:p-3 ${
+                      isToday ? 'bg-knowall-green/10' : ''
+                    }`}
+                  >
+                    <p className="text-xs font-medium uppercase text-dark-400">
+                      {format(day, 'EEE')}
+                    </p>
+                    <p
+                      className={`text-base font-semibold sm:text-lg ${
+                        isToday ? 'text-knowall-green' : 'text-white'
+                      }`}
+                    >
+                      {format(day, 'd')}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
 
-              return (
-                <TimeEntryCell
-                  key={day.toISOString()}
-                  entries={dayEntries}
-                  date={dateStr}
-                  isToday={isToday}
-                  projects={projects}
-                  onAddEntry={handleAddEntry}
-                  onEditEntry={handleEditEntry}
-                />
-              );
-            })}
+            {/* Entries Grid */}
+            {isLoading ? (
+              <div className="flex h-64 items-center justify-center">
+                <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-knowall-green"></div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-7">
+                {weekDays.map((day) => {
+                  const dateStr = formatDate(day);
+                  const dayEntries = getEntriesForDay(dateStr);
+                  const isToday = isDayToday(day);
+
+                  return (
+                    <TimeEntryCell
+                      key={day.toISOString()}
+                      entries={dayEntries}
+                      date={dateStr}
+                      isToday={isToday}
+                      projects={projects}
+                      onAddEntry={handleAddEntry}
+                      onEditEntry={handleEditEntry}
+                    />
+                  );
+                })}
+              </div>
+            )}
           </div>
-        )}
+        </div>
 
         {/* Empty State */}
         {!isLoading && entries.length === 0 && (


### PR DESCRIPTION
Add responsive design to the timesheet for screens <640px wide:

- WeeklyTimesheet: Add horizontal scroll wrapper with min-width to
  maintain usable column widths on mobile, add scroll hint for mobile
  users, make header stack vertically on small screens

- TimeEntryCell: Reduce min-height and padding on mobile while
  maintaining usability, add last:border-r-0 to fix border issues

- TimerDisplay: Add truncate to prevent long project names from
  overflowing, reduce gaps and padding on mobile, add shrink-0 to
  prevent timer display from compressing

Closes #12