### PR TITLE
fix: Add NEXT_PUBLIC_ prefix to BC environment variables for client access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ NEXT_PUBLIC_AZURE_TENANT_ID=your-tenant-id
 NEXT_PUBLIC_AZURE_REDIRECT_URI=http://localhost:3000
 
 # Business Central Configuration
-BC_ENVIRONMENT=sandbox
-BC_COMPANY_ID=your-business-central-company-guid
+NEXT_PUBLIC_BC_ENVIRONMENT=sandbox
+NEXT_PUBLIC_BC_COMPANY_ID=your-business-central-company-guid
 NEXT_PUBLIC_BC_BASE_URL=https://api.businesscentral.dynamics.com/v2.0
 
 # Application Configuration

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -15,7 +15,7 @@ Common issues and their solutions. Add new entries as problems are discovered an
 | User needs appropriate Business Central license and permissions assigned
 
 | Projects dropdown is empty
-| Verify `BC_COMPANY_ID` is correct; check that `/projects` endpoint returns data (not `/jobs`)
+| Verify `NEXT_PUBLIC_BC_COMPANY_ID` and `NEXT_PUBLIC_BC_ENVIRONMENT` are set (must have `NEXT_PUBLIC_` prefix for client-side access); check that `/projects` endpoint returns data (not `/jobs`)
 
 | Team page shows no employees
 | Ensure employees exist in BC with status 'Active'; check `/employees` endpoint

--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -11,8 +11,8 @@ import type {
 
 const BC_BASE_URL =
   process.env.NEXT_PUBLIC_BC_BASE_URL || 'https://api.businesscentral.dynamics.com/v2.0';
-const BC_ENVIRONMENT = process.env.BC_ENVIRONMENT || 'sandbox';
-const BC_COMPANY_ID = process.env.BC_COMPANY_ID || '';
+const BC_ENVIRONMENT = process.env.NEXT_PUBLIC_BC_ENVIRONMENT || 'sandbox';
+const BC_COMPANY_ID = process.env.NEXT_PUBLIC_BC_COMPANY_ID || '';
 
 class BusinessCentralClient {
   private baseUrl: string;


### PR DESCRIPTION
Environment variables BC_ENVIRONMENT and BC_COMPANY_ID were not accessible
in the browser because they lacked the NEXT_PUBLIC_ prefix. This caused
the projects dropdown to be empty in production as the BC API client was
constructing malformed URLs with empty company ID and wrong environment.

Fixes #25