### PR TITLE
Fix leaf alignment in homepage logo

### DIFF
--- a/public/social-preview.svg
+++ b/public/social-preview.svg
@@ -37,8 +37,8 @@
     <rect x="478" y="160" width="80" height="80" rx="16" fill="#00D26A"/>
   </g>
 
-  <!-- Thyme sprig icon - angled 45 degrees, white on green -->
-  <g transform="translate(518, 200) rotate(-45 0 0)">
+  <!-- Thyme sprig icon - angled 45 degrees, white on green, centered in box -->
+  <g transform="translate(518, 200) rotate(-45) translate(0, -20)">
     <path d="M0 50 Q-3 35 0 18 Q2 8 6 -5" stroke="white" stroke-width="4.5" stroke-linecap="round" fill="none"/>
     <circle cx="-6" cy="40" r="5.5" fill="white"/>
     <circle cx="5" cy="33" r="4.5" fill="white"/>


### PR DESCRIPTION
The thyme sprig icon was misaligned because it rotated around (0,0) while the icon's visual center was at approximately (0, 20). Added a translate(0, -20) before the rotation to properly center the icon within the green logo box.

## Summary

Brief description of the changes in this PR.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update
- [ ] Refactoring

## Changes Made

- Updated logo

## Testing

## Checklist

- [ ] I have run `npm run check` and all checks pass
- [ ] My code follows the project's coding style
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
