### PR TITLE
feat: Add toast notifications for auth and sync operations

### DIFF
--- a/src/services/auth/AuthProvider.tsx
+++ b/src/services/auth/AuthProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
 import {
   MsalProvider,
   AuthenticatedTemplate,
@@ -50,6 +51,7 @@ export function useAuth() {
       await instance.loginRedirect(loginRequest);
     } catch (error) {
       console.error('Login failed:', error);
+      toast.error('Login failed. Please try again.');
       throw error;
     }
   };

--- a/src/services/auth/tokenService.ts
+++ b/src/services/auth/tokenService.ts
@@ -1,4 +1,5 @@
 import { SilentRequest } from '@azure/msal-browser';
+import toast from 'react-hot-toast';
 import { bcTokenRequest, graphTokenRequest } from './msalConfig';
 import { msalInstance, initializeMsal } from './msalInstance';
 
@@ -13,6 +14,8 @@ export async function getAccessToken(
 
     if (!account) {
       console.error('No active account found');
+      // Use toast ID to prevent duplicate notifications when multiple API calls fail
+      toast.error('Session expired. Please sign in again.', { id: 'session-expired' });
       return null;
     }
 

--- a/src/services/bc/timeEntryService.ts
+++ b/src/services/bc/timeEntryService.ts
@@ -1,5 +1,6 @@
+import toast from 'react-hot-toast';
 import { bcClient } from './bcClient';
-import type { TimeEntry, BCJobJournalLine, Project, Task } from '@/types';
+import type { TimeEntry, BCJobJournalLine, Project } from '@/types';
 import { format, parseISO } from 'date-fns';
 
 // Local storage key for time entries (cached/pending sync)
@@ -147,6 +148,22 @@ export const timeEntryService = {
     }
 
     saveLocalEntries(entries);
+
+    // Show user-friendly notifications for sync results
+    if (synced > 0 && failed === 0) {
+      toast.success(
+        `Successfully synced ${synced} time ${synced === 1 ? 'entry' : 'entries'} to Business Central`
+      );
+    } else if (synced > 0 && failed > 0) {
+      toast.error(
+        `Synced ${synced} ${synced === 1 ? 'entry' : 'entries'}, but ${failed} failed. Check console for details.`
+      );
+    } else if (failed > 0) {
+      toast.error(
+        `Failed to sync ${failed} time ${failed === 1 ? 'entry' : 'entries'}. Please try again.`
+      );
+    }
+
     return { synced, failed };
   },
 


### PR DESCRIPTION
## Summary

- Add login failure toast in AuthProvider
- Add session expired toast in tokenService (with dedup ID to prevent multiple toasts when several API calls fail)
- Add sync success/failure toasts in timeEntryService with entry counts

## Background

Cherry-picked useful additions from closed PR #19 that weren't included in #28.

## Test plan

- [ ] Trigger login failure (e.g., cancel auth flow) - should show "Login failed" toast
- [ ] Let session expire, make API call - should show "Session expired" toast (only once)
- [ ] Sync time entries to BC - should show success/failure toast with counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)