### PR TITLE
feat: Add 'Return to this week' link when viewing past/future weeks

### DIFF
--- a/src/components/timesheet/WeekNavigation.tsx
+++ b/src/components/timesheet/WeekNavigation.tsx
@@ -35,9 +35,12 @@ export function WeekNavigation({
       <h2 className="text-lg font-semibold text-white">{formatWeekRange(currentWeekStart)}</h2>
 
       {!isCurrentWeek && (
-        <Button variant="ghost" size="sm" onClick={onToday}>
-          Today
-        </Button>
+        <button
+          onClick={onToday}
+          className="text-sm text-primary hover:text-primary/80 hover:underline transition-colors"
+        >
+          Return to this week
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
Replace the "Today" button with a styled link that says "Return to this week"
when the user is viewing a week other than the current week. The link is
styled to match the design pattern shown in similar time tracking apps.