### PR TITLE
fix: Prevent infinite loop in approval photo fetching

### DIFF
--- a/src/components/approvals/ApprovalList.tsx
+++ b/src/components/approvals/ApprovalList.tsx
@@ -170,7 +170,7 @@ export function ApprovalList() {
       pendingApprovals.forEach((ts) => {
         if (ts.resourceEmail && emailDomain) {
           const email = `${ts.resourceEmail}@${emailDomain}`;
-          if (!photosCache[email]) {
+          if (!(email in photosCache)) {
             uniqueEmails.add(email);
           }
         }


### PR DESCRIPTION
## Summary

- Fixed infinite loop that caused approve/reject buttons to become unresponsive
- Changed photo cache check from `!photosCache[email]` to `!(email in photosCache)`
- The bug occurred because `!null === true`, so failed photo fetches (cached as `null`) triggered re-fetches infinitely

## Test plan

- [ ] Navigate to Approvals page with pending timesheets
- [ ] Verify no infinite 403 errors in console
- [ ] Verify approve and reject buttons respond to clicks
- [ ] Verify profile photos still load for users who have them

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)