### PR TITLE
fix: Display correct environment on Settings page

### DIFF
--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -251,7 +251,11 @@ export function SettingsPanel() {
           <p className="text-dark-100">Connected to Business Central</p>
         </div>
         <p className="text-dark-400 mt-2 text-sm">
-          Environment: {process.env.BC_ENVIRONMENT || 'Production'}
+          Environment:{' '}
+          {selectedCompany?.environment
+            ? selectedCompany.environment.charAt(0).toUpperCase() +
+              selectedCompany.environment.slice(1)
+            : 'Unknown'}
         </p>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

The environment was always showing "Production" on the Settings - Account page because it was using `process.env.BC_ENVIRONMENT` which is a server-side variable not available in the browser.

## Fix

Now uses `selectedCompany.environment` from the company store to display the actual environment (Sandbox/Production) the user is connected to. 

<img width="1162" height="882" alt="image" src="https://github.com/user-attachments/assets/edd867b5-639e-4280-944b-5eaf32ea7398" />


## Changes

**SettingsPanel.tsx:**
- Replaced `process.env.BC_ENVIRONMENT || 'Production'` with `selectedCompany?.environment`
- Added proper capitalization (sandbox → Sandbox, production → Production)

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)