### PR TITLE
fix: Reset project/task selection after saving new time entry

### DIFF
--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -225,6 +225,8 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
           isBillable: task?.isBillable ?? true,
           isRunning: false,
         });
+        // Reset selected project/task so next new entry starts fresh
+        selectProject(null);
       }
       toast.success(entry ? 'Time entry updated' : 'Time entry saved');
       onClose();


### PR DESCRIPTION
## Summary

When adding a time entry, the previous project/task values were retained in the form fields, requiring users to manually clear or change them for each new entry.

## Root Cause

After saving a new entry, `selectedProject` and `selectedTask` in the projects store were not reset. When opening the modal for a new entry, these values were used to pre-populate the form.

## Fix

Call `selectProject(null)` after successfully saving a new entry (not when editing). This resets both `selectedProject` and `selectedTask` in the store, so the next new entry starts with empty fields.

## Changes

**TimeEntryModal.tsx:**
- Added `selectProject(null)` after saving a new entry to reset the selection

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)