### PR TITLE
fix: Improve Plan screen UX and use British date format

### DIFF
--- a/src/components/plan/PlanPanel.tsx
+++ b/src/components/plan/PlanPanel.tsx
@@ -1639,6 +1639,8 @@ export function PlanPanel() {
               setLocalWeekStart(weekStart);
               setCurrentWeekStart(weekStart);
             }}
+            weeksToShow={effectiveWeeksToShow}
+            alwaysShowToday
           />
         </div>
 

--- a/src/components/reports/ReportsPanel.tsx
+++ b/src/components/reports/ReportsPanel.tsx
@@ -31,7 +31,13 @@ import {
 import { useAuth } from '@/services/auth';
 import { useProjectsStore, useCompanyStore } from '@/hooks';
 import { timeEntryService, bcClient } from '@/services/bc';
-import { cn, formatTime } from '@/utils';
+import {
+  cn,
+  formatTime,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_SHORT,
+  DATE_FORMAT_DAY_SHORT,
+} from '@/utils';
 import type { TimeEntry, BCResource } from '@/types';
 
 type DateRange = 'week' | 'month';
@@ -259,7 +265,7 @@ export function ReportsPanel() {
       const data = dailyData[dateStr] || { hours: 0, billableHours: 0 };
       return {
         date: dateStr,
-        label: format(day, 'EEE, d MMM'),
+        label: format(day, DATE_FORMAT_DAY_SHORT),
         hours: data.hours,
         billableHours: data.billableHours,
       };
@@ -279,9 +285,9 @@ export function ReportsPanel() {
       const startMonth = format(startDate, 'MMM');
       const endMonth = format(endDate, 'MMM');
       if (startMonth === endMonth) {
-        return `${format(startDate, 'd')} - ${format(endDate, 'd MMM yyyy')}`;
+        return `${format(startDate, 'd')} - ${format(endDate, DATE_FORMAT_FULL)}`;
       }
-      return `${format(startDate, 'd MMM')} - ${format(endDate, 'd MMM yyyy')}`;
+      return `${format(startDate, DATE_FORMAT_SHORT)} - ${format(endDate, DATE_FORMAT_FULL)}`;
     }
     return format(referenceDate, 'MMMM yyyy');
   };

--- a/src/components/ui/DatePicker.tsx
+++ b/src/components/ui/DatePicker.tsx
@@ -14,16 +14,23 @@ import {
   endOfWeek,
 } from 'date-fns';
 import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
-import { cn } from '@/utils';
+import { cn, DATE_FORMAT_FULL } from '@/utils';
 import { Button } from './Button';
 
 export interface DatePickerProps {
   selectedDate?: Date;
   onDateSelect: (date: Date) => void;
   className?: string;
+  /** Show only the calendar icon without date text */
+  iconOnly?: boolean;
 }
 
-export function DatePicker({ selectedDate, onDateSelect, className }: DatePickerProps) {
+export function DatePicker({
+  selectedDate,
+  onDateSelect,
+  className,
+  iconOnly = false,
+}: DatePickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [viewDate, setViewDate] = useState(selectedDate || new Date());
   const containerRef = useRef<HTMLDivElement>(null);
@@ -101,15 +108,18 @@ export function DatePicker({ selectedDate, onDateSelect, className }: DatePicker
         aria-label="Open date picker"
         aria-expanded={isOpen}
         className={cn(
-          'border-dark-600 bg-dark-700 flex h-10 w-full items-center gap-2 rounded-lg border px-3 text-sm transition-colors',
+          'border-dark-600 bg-dark-700 flex h-10 items-center gap-2 rounded-lg border text-sm transition-colors',
           'hover:border-dark-500 focus:border-thyme-500 focus:ring-thyme-500 focus:ring-1 focus:outline-none',
+          iconOnly ? 'w-10 justify-center' : 'w-full px-3',
           selectedDate ? 'text-white' : 'text-dark-400'
         )}
       >
         <CalendarIcon className="text-dark-400 h-4 w-4 shrink-0" />
-        <span className="truncate">
-          {selectedDate ? format(selectedDate, 'd MMM yyyy') : 'Select date'}
-        </span>
+        {!iconOnly && (
+          <span className="truncate">
+            {selectedDate ? format(selectedDate, DATE_FORMAT_FULL) : 'Select date'}
+          </span>
+        )}
       </button>
 
       {isOpen && (

--- a/src/components/ui/WeekNavigation.tsx
+++ b/src/components/ui/WeekNavigation.tsx
@@ -1,9 +1,16 @@
 'use client';
 
+import { addWeeks, endOfWeek, format } from 'date-fns';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { Button } from './Button';
 import { DatePicker } from './DatePicker';
-import { formatWeekRange, getWeekStart, isSameDayAs } from '@/utils';
+import {
+  formatWeekRange,
+  getWeekStart,
+  isSameDayAs,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_SHORT,
+} from '@/utils';
 
 export interface WeekNavigationProps {
   currentWeekStart: Date;
@@ -11,6 +18,24 @@ export interface WeekNavigationProps {
   onNext: () => void;
   onToday: () => void;
   onDateSelect: (date: Date) => void;
+  /** Number of weeks being displayed (default: 1) */
+  weeksToShow?: number;
+  /** Always show Today button even when on current week (default: false) */
+  alwaysShowToday?: boolean;
+}
+
+/**
+ * Format a date range spanning multiple weeks
+ */
+function formatMultiWeekRange(startDate: Date, weeksToShow: number): string {
+  const endDate = endOfWeek(addWeeks(startDate, weeksToShow - 1), { weekStartsOn: 1 });
+  const startMonth = format(startDate, 'MMM');
+  const endMonth = format(endDate, 'MMM');
+
+  if (startMonth === endMonth) {
+    return `${format(startDate, 'd')} - ${format(endDate, DATE_FORMAT_FULL)}`;
+  }
+  return `${format(startDate, DATE_FORMAT_SHORT)} - ${format(endDate, DATE_FORMAT_FULL)}`;
 }
 
 export function WeekNavigation({
@@ -19,8 +44,16 @@ export function WeekNavigation({
   onNext,
   onToday,
   onDateSelect,
+  weeksToShow = 1,
+  alwaysShowToday = false,
 }: WeekNavigationProps) {
   const isCurrentWeek = isSameDayAs(currentWeekStart, getWeekStart(new Date()));
+  const showTodayButton = alwaysShowToday || !isCurrentWeek;
+
+  const dateRangeLabel =
+    weeksToShow > 1
+      ? formatMultiWeekRange(currentWeekStart, weeksToShow)
+      : formatWeekRange(currentWeekStart);
 
   return (
     <div className="flex items-center gap-4">
@@ -35,11 +68,11 @@ export function WeekNavigation({
         </Button>
       </div>
 
-      <DatePicker selectedDate={currentWeekStart} onDateSelect={onDateSelect} />
+      <DatePicker selectedDate={currentWeekStart} onDateSelect={onDateSelect} iconOnly />
 
-      <h2 className="text-lg font-semibold text-white">{formatWeekRange(currentWeekStart)}</h2>
+      <h2 className="text-lg font-semibold text-white">{dateRangeLabel}</h2>
 
-      {!isCurrentWeek && (
+      {showTodayButton && (
         <Button variant="ghost" size="sm" onClick={onToday}>
           Today
         </Button>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -14,6 +14,11 @@ import {
 // Week starts on Monday
 const WEEK_OPTIONS = { weekStartsOn: 1 as const };
 
+// British date format constants
+export const DATE_FORMAT_FULL = 'd MMM yyyy'; // e.g., "3 Feb 2026"
+export const DATE_FORMAT_SHORT = 'd MMM'; // e.g., "3 Feb"
+export const DATE_FORMAT_DAY_SHORT = 'EEE, d MMM'; // e.g., "Mon, 3 Feb"
+
 export function getWeekStart(date: Date = new Date()): Date {
   return startOfWeek(date, WEEK_OPTIONS);
 }
@@ -43,7 +48,7 @@ export function formatDate(date: Date | string, formatStr: string = 'yyyy-MM-dd'
 }
 
 export function formatDateForDisplay(date: Date | string): string {
-  return formatDate(date, 'EEE, d MMM');
+  return formatDate(date, DATE_FORMAT_DAY_SHORT);
 }
 
 export function formatWeekRange(weekStart: Date): string {
@@ -52,9 +57,9 @@ export function formatWeekRange(weekStart: Date): string {
   const endMonth = format(weekEnd, 'MMM');
 
   if (startMonth === endMonth) {
-    return `${format(weekStart, 'd')} - ${format(weekEnd, 'd MMM yyyy')}`;
+    return `${format(weekStart, 'd')} - ${format(weekEnd, DATE_FORMAT_FULL)}`;
   }
-  return `${format(weekStart, 'd MMM')} - ${format(weekEnd, 'd MMM yyyy')}`;
+  return `${format(weekStart, DATE_FORMAT_SHORT)} - ${format(weekEnd, DATE_FORMAT_FULL)}`;
 }
 
 export function isDayToday(date: Date | string): boolean {


### PR DESCRIPTION
## Summary

- Replace custom "Today" navigation with reusable WeekNavigation component showing dynamic week range
- Fix rounded corners on Team/Projects toggle buttons (corners stay rounded when selected)
- Use British date format (d MMM yyyy) across Plan, Time, Team, and Reports screens

## Fixes

- Fixes #90
- Fixes #103
- Fixes #117

<img width="1336" height="818" alt="image" src="https://github.com/user-attachments/assets/3a902705-b729-4d25-a2ee-19412b2e12bc" />

## Test plan

- [ ] Navigate to Plan screen
- [ ] Verify week navigation shows date range (e.g., "2 - 8 Feb 2026") instead of static "Today"
- [ ] Click prev/next arrows and verify date range updates
- [ ] Verify Team/Projects buttons keep rounded corners when selected
- [ ] Verify date picker shows British format (e.g., "3 Feb 2026")
- [ ] Check Time, Team, and Reports screens also show British date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)