### PR TITLE
fix: Hide Billable Price when costs are hidden

### DIFF
--- a/src/components/projects/ProjectKPICards.tsx
+++ b/src/components/projects/ProjectKPICards.tsx
@@ -255,11 +255,13 @@ export function ProjectKPICards() {
     },
     {
       label: 'Billable Price',
-      value: formatCurrency(billablePrice, currencyCode),
-      subLabel: 'From Job Planning Lines',
-      breakdown: billableBreakdown,
+      value: showCosts ? formatCurrency(billablePrice, currencyCode) : '•••••',
+      subLabel: showCosts ? 'From Job Planning Lines' : 'Hidden',
+      breakdown: showCosts ? billableBreakdown : null,
       icon: CurrencyPoundIcon,
       color: 'text-blue-400',
+      isInternal: true,
+      isHidden: !showCosts,
       tooltip: {
         title: 'Billable Price (Customer)',
         description:


### PR DESCRIPTION
## Summary
- Hides the "Billable Price" KPI card when the "Costs hidden" toggle is active
- Now consistent with Budget Cost and Actual Cost behavior

## Issue Fixed
Fixes #138

## Test plan
- [ ] Navigate to a project detail page
- [ ] Click "Costs hidden" toggle button
- [ ] Verify Budget Cost, Actual Cost, AND Billable Price are all hidden
- [ ] Click "Costs visible" to show them again

🤖 Generated with [Claude Code](https://claude.com/claude-code)