### PR TITLE
fix: Change local dev port from 3001 to 3101

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,8 @@ The redirect URI is determined dynamically using `window.location.origin`, so it
 
 **Registered SPA Redirect URIs:**
 
-- `http://localhost:3000` - Default local dev
-- `http://localhost:3001` - Alternate local dev port
+- `http://localhost:3000` - Default Next.js port
+- `http://localhost:3101` - Local dev port (configured in package.json)
 - `https://getthyme.ai` - Production
 - `https://slot1-4.thyme.knowall.ai` - Staging slots
 
@@ -133,7 +133,7 @@ To check or update redirect URIs:
 az ad app show --id "44c618b5-89c3-4673-92ec-f7afb4e403bf" --query "spa.redirectUris"
 
 # Add a new redirect URI (replace with full list)
-az ad app update --id "44c618b5-89c3-4673-92ec-f7afb4e403bf" --spa-redirect-uris "http://localhost:3000" "http://localhost:3001" "https://getthyme.ai"
+az ad app update --id "44c618b5-89c3-4673-92ec-f7afb4e403bf" --spa-redirect-uris "http://localhost:3000" "http://localhost:3101" "https://getthyme.ai"
 ```
 
 ## Adding UI Components

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Time tracking application for Microsoft Dynamics 365 Business Central",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "next dev -p 3101",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Changed the local dev server port from `3001` to `3101` in `package.json`
- Updated `CLAUDE.md` to reflect the new port in redirect URI documentation
- Updated Azure AD app registration to replace `localhost:3001` with `localhost:3101`

<img width="1650" height="672" alt="image" src="https://github.com/user-attachments/assets/bdbaa846-2e70-4611-8a8a-75632711dec3" />

Closes #144

## Test plan
- [x] Dev server starts on port 3101
- [x] Azure AD redirect URI updated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)