### PR TITLE
fix: Allow any minute value (0-59) in time entry modal

### DIFF
--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -33,14 +33,6 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
   const [taskId, setTaskId] = useState('');
   const [hours, setHours] = useState('');
   const [minutes, setMinutes] = useState('');
-
-  // When hours is 24, minutes must be 0
-  const handleHoursChange = (value: string) => {
-    setHours(value);
-    if (parseInt(value) >= 24) {
-      setMinutes('0');
-    }
-  };
   const [notes, setNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [extensionInstalled, setExtensionInstalled] = useState<boolean | null>(null);
@@ -128,8 +120,8 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
         setTaskId(task?.id || '');
         const h = Math.floor(entry.hours);
         const m = Math.round((entry.hours - h) * 60);
-        setHours(h.toString());
-        setMinutes(m.toString());
+        setHours(h > 0 ? h.toString() : '');
+        setMinutes(m > 0 ? m.toString() : '');
         setNotes(entry.notes || '');
       } else {
         // New entry - use matching customer option value
@@ -341,15 +333,17 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
             min="0"
             max="24"
             value={hours}
-            onChange={(e) => handleHoursChange(e.target.value)}
+            onChange={(e) => {
+              setHours(e.target.value);
+              if (parseInt(e.target.value) >= 24) setMinutes('0');
+            }}
             placeholder="0"
           />
           <Input
             label="Minutes"
             type="number"
             min="0"
-            max="45"
-            step="15"
+            max="59"
             value={minutes}
             onChange={(e) => setMinutes(e.target.value)}
             placeholder="0"

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -118,8 +118,9 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
         // Find task by code and use its id
         const task = project?.tasks.find((t) => t.code === entry.taskId);
         setTaskId(task?.id || '');
-        const h = Math.floor(entry.hours);
-        const m = Math.round((entry.hours - h) * 60);
+        const totalMinutes = Math.round(entry.hours * 60);
+        const h = Math.floor(totalMinutes / 60);
+        const m = totalMinutes % 60;
         setHours(h > 0 ? h.toString() : '');
         setMinutes(m > 0 ? m.toString() : '');
         setNotes(entry.notes || '');
@@ -175,7 +176,9 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
     e.preventDefault();
     if (!date || !projectId || !taskId || isSubmitting) return;
 
-    const totalHours = (parseInt(hours) || 0) + (parseInt(minutes) || 0) / 60;
+    const h = Math.max(0, Math.min(24, parseInt(hours) || 0));
+    const m = h >= 24 ? 0 : Math.max(0, Math.min(59, parseInt(minutes) || 0));
+    const totalHours = h + m / 60;
     if (totalHours <= 0) return;
 
     const project = projects.find((p) => p.id === projectId);
@@ -334,8 +337,14 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
             max="24"
             value={hours}
             onChange={(e) => {
-              setHours(e.target.value);
-              if (parseInt(e.target.value) >= 24) setMinutes('0');
+              const v = e.target.value;
+              if (v === '') {
+                setHours('');
+                return;
+              }
+              const n = Math.max(0, Math.min(24, parseInt(v) || 0));
+              setHours(n.toString());
+              if (n >= 24) setMinutes('0');
             }}
             placeholder="0"
           />
@@ -345,7 +354,15 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
             min="0"
             max="59"
             value={minutes}
-            onChange={(e) => setMinutes(e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === '') {
+                setMinutes('');
+                return;
+              }
+              const n = Math.max(0, Math.min(59, parseInt(v) || 0));
+              setMinutes(n.toString());
+            }}
             placeholder="0"
             disabled={parseInt(hours) >= 24}
           />


### PR DESCRIPTION
## Summary
- Removed 15-minute step restriction on the Minutes input in the time entry modal, allowing any value from 0-59
- Changed minutes max from 45 to 59 so users can log precise times like 1h 45m
- Inlined the `handleHoursChange` helper and improved empty-state display when editing entries
<img width="997" height="814" alt="image" src="https://github.com/user-attachments/assets/da828ece-af34-43b3-9a33-d317770de657" />
<img width="624" height="619" alt="image" src="https://github.com/user-attachments/assets/b445b0a2-88aa-4519-896e-33ecb6515918" />

Closes #177

## Test plan
- [x] Open the time entry modal and verify the Minutes field accepts any value from 0-59
- [x] Enter 1h 45m and confirm it saves and displays as 1h 45m
- [x] Enter 0h 15m and confirm it saves and displays as 15m
- [x] Enter 24h and confirm minutes is disabled and reset to 0
- [x] Edit an existing entry and verify hours/minutes populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)