### PR TITLE
fix: Allow 0.25h (15-minute) increments in Plan hours

### DIFF
--- a/src/components/plan/PlanEditModal.tsx
+++ b/src/components/plan/PlanEditModal.tsx
@@ -115,8 +115,8 @@ export function PlanEditModal({
         const totalQuantity = lines.reduce((sum, l) => sum + l.quantity, 0);
         // Convert base unit to hours using shared conversion utility
         const totalHours = convertToHours(allocation.resourceNumber, totalQuantity, conversionMap);
-        // Round to nearest 0.5 hour
-        const rounded = Math.round(totalHours * 2) / 2;
+        // Round to nearest 0.25 hour (15-minute increments)
+        const rounded = Math.round(totalHours * 4) / 4;
         hours[date] = rounded.toString();
       }
 
@@ -431,7 +431,7 @@ export function PlanEditModal({
                     onChange={(e) => handleHoursChange(dateKey, e.target.value)}
                     min="0"
                     max="24"
-                    step="0.5"
+                    step="0.25"
                     disabled={isLoadingExisting}
                     className={`border-dark-600 bg-dark-700 text-dark-100 focus:ring-knowall-green h-8 w-full [appearance:textfield] rounded border px-1 text-right text-sm focus:ring-1 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${hasExistingLine ? 'border-knowall-green/50' : ''}`}
                     placeholder="0"
@@ -457,7 +457,7 @@ export function PlanEditModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{totalHours.toFixed(1)}h</span>
+          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/PlanEditModal.tsx
+++ b/src/components/plan/PlanEditModal.tsx
@@ -12,6 +12,7 @@ import {
   buildUOMConversionMap,
   convertToHours,
   convertFromHours,
+  formatHours,
   type UOMConversionMap,
 } from '@/utils';
 import { ResourceWorkload } from './ResourceWorkload';
@@ -457,7 +458,7 @@ export function PlanEditModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
+          <span className="text-dark-100 font-medium">{formatHours(totalHours)}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/PlanEntryModal.tsx
+++ b/src/components/plan/PlanEntryModal.tsx
@@ -12,6 +12,7 @@ import {
   buildUOMConversionMap,
   convertToHours,
   convertFromHours,
+  formatHours,
   type UOMConversionMap,
 } from '@/utils';
 import { ResourceWorkload } from './ResourceWorkload';
@@ -531,7 +532,7 @@ export function PlanEntryModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
+          <span className="text-dark-100 font-medium">{formatHours(totalHours)}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/PlanEntryModal.tsx
+++ b/src/components/plan/PlanEntryModal.tsx
@@ -163,8 +163,8 @@ export function PlanEntryModal({
           const hoursValue = convertToHours(resourceNumber, line.quantity, uomMap);
           // If there are multiple lines for the same day, sum them
           const existingVal = parseFloat(newHours[dateKey] || '0');
-          // Round to nearest 0.5 hour
-          const rounded = Math.round((existingVal + hoursValue) * 2) / 2;
+          // Round to nearest 0.25 hour (15-minute increments)
+          const rounded = Math.round((existingVal + hoursValue) * 4) / 4;
           newHours[dateKey] = rounded.toString();
           // Track id and etag for updates (last one wins if multiple)
           newLinesByDate[dateKey] = { id: line.id, etag: line['@odata.etag'] || '' };
@@ -505,7 +505,7 @@ export function PlanEntryModal({
                     onChange={(e) => handleDayHoursChange(dateKey, e.target.value)}
                     min="0"
                     max="24"
-                    step="0.5"
+                    step="0.25"
                     disabled={isLoadingExisting}
                     className={`border-dark-600 bg-dark-700 text-dark-100 focus:ring-knowall-green h-8 w-full [appearance:textfield] rounded border px-1 text-right text-sm focus:ring-1 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${hasExistingLine ? 'border-knowall-green/50' : ''}`}
                     placeholder="0"
@@ -531,7 +531,7 @@ export function PlanEntryModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{totalHours.toFixed(1)}h</span>
+          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/PlanPanel.tsx
+++ b/src/components/plan/PlanPanel.tsx
@@ -22,7 +22,7 @@ import { usePlanStore } from '@/hooks';
 import { useCompanyStore } from '@/hooks';
 import { useAuth, getUserProfilePhoto } from '@/services/auth';
 import { ExtensionNotInstalledError } from '@/services/bc';
-import { cn, getBCResourceUrl, getBCJobUrl } from '@/utils';
+import { cn, getBCResourceUrl, getBCJobUrl, formatHours } from '@/utils';
 import type { AllocationBlock, PlanTeamMember, PlanProject, ViewMode } from '@/hooks/usePlanStore';
 import {
   addWeeks,
@@ -266,7 +266,7 @@ function ResourceRow({
                         onClick={onToggleExpand}
                         title="Click to expand and edit allocations"
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -294,7 +294,7 @@ function ResourceRow({
 
         {/* Total Hours */}
         <div className="text-dark-300 w-16 shrink-0 px-2 text-right text-sm">
-          {member.totalHours > 0 && `${parseFloat(member.totalHours.toFixed(2))}h`}
+          {member.totalHours > 0 && `${formatHours(member.totalHours)}h`}
         </div>
       </div>
 
@@ -538,7 +538,7 @@ function TeamTaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-medium text-white/80"
                         style={{ backgroundColor: `${projectData.color}99` }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -567,7 +567,7 @@ function TeamTaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-500 w-16 shrink-0 px-2 text-right text-[10px]">
-        {parseFloat(taskTotalHours.toFixed(2))}h
+        {formatHours(taskTotalHours)}h
       </div>
     </div>
   );
@@ -674,7 +674,7 @@ function TeamProjectRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-semibold text-white"
                         style={{ backgroundColor: projectData.color }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -702,7 +702,7 @@ function TeamProjectRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-400 w-16 shrink-0 px-2 text-right text-xs">
-        {parseFloat(projectTotalHours.toFixed(2))}h
+        {formatHours(projectTotalHours)}h
       </div>
     </div>
   );
@@ -807,7 +807,7 @@ function TaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-semibold text-white"
                         style={{ backgroundColor: projectColor }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -833,7 +833,7 @@ function TaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-400 w-16 shrink-0 px-2 text-right text-xs">
-        {parseFloat(taskTotalHours.toFixed(2))}h
+        {formatHours(taskTotalHours)}h
       </div>
     </div>
   );
@@ -953,7 +953,7 @@ function ResourceTaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-medium text-white/80"
                         style={{ backgroundColor: `${projectColor}99` }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -982,7 +982,7 @@ function ResourceTaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-500 w-16 shrink-0 px-2 text-right text-[10px]">
-        {parseFloat(allocations.reduce((sum, a) => sum + a.totalHours, 0).toFixed(2))}h
+        {formatHours(allocations.reduce((sum, a) => sum + a.totalHours, 0))}h
       </div>
     </div>
   );
@@ -1182,7 +1182,7 @@ function ProjectRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-xs font-semibold text-white"
                         style={{ backgroundColor: project.color }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
+                        {dayHours % 1 === 0 ? dayHours : formatHours(dayHours)}
                       </div>
                     )}
                   </div>
@@ -1210,7 +1210,7 @@ function ProjectRow({
 
         {/* Total Hours */}
         <div className="text-dark-300 w-16 shrink-0 px-2 text-right text-sm">
-          {project.totalHours > 0 && `${parseFloat(project.totalHours.toFixed(2))}h`}
+          {project.totalHours > 0 && `${formatHours(project.totalHours)}h`}
         </div>
       </div>
 

--- a/src/components/plan/PlanPanel.tsx
+++ b/src/components/plan/PlanPanel.tsx
@@ -266,7 +266,7 @@ function ResourceRow({
                         onClick={onToggleExpand}
                         title="Click to expand and edit allocations"
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -294,7 +294,7 @@ function ResourceRow({
 
         {/* Total Hours */}
         <div className="text-dark-300 w-16 shrink-0 px-2 text-right text-sm">
-          {member.totalHours > 0 && `${member.totalHours.toFixed(1)}h`}
+          {member.totalHours > 0 && `${parseFloat(member.totalHours.toFixed(2))}h`}
         </div>
       </div>
 
@@ -538,7 +538,7 @@ function TeamTaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-medium text-white/80"
                         style={{ backgroundColor: `${projectData.color}99` }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -567,7 +567,7 @@ function TeamTaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-500 w-16 shrink-0 px-2 text-right text-[10px]">
-        {taskTotalHours.toFixed(1)}h
+        {parseFloat(taskTotalHours.toFixed(2))}h
       </div>
     </div>
   );
@@ -674,7 +674,7 @@ function TeamProjectRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-semibold text-white"
                         style={{ backgroundColor: projectData.color }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -702,7 +702,7 @@ function TeamProjectRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-400 w-16 shrink-0 px-2 text-right text-xs">
-        {projectTotalHours.toFixed(1)}h
+        {parseFloat(projectTotalHours.toFixed(2))}h
       </div>
     </div>
   );
@@ -807,7 +807,7 @@ function TaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-semibold text-white"
                         style={{ backgroundColor: projectColor }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -833,7 +833,7 @@ function TaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-400 w-16 shrink-0 px-2 text-right text-xs">
-        {taskTotalHours.toFixed(1)}h
+        {parseFloat(taskTotalHours.toFixed(2))}h
       </div>
     </div>
   );
@@ -953,7 +953,7 @@ function ResourceTaskRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-[10px] font-medium text-white/80"
                         style={{ backgroundColor: `${projectColor}99` }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -982,7 +982,7 @@ function ResourceTaskRow({
       </div>
       {/* Total hours */}
       <div className="text-dark-500 w-16 shrink-0 px-2 text-right text-[10px]">
-        {allocations.reduce((sum, a) => sum + a.totalHours, 0).toFixed(1)}h
+        {parseFloat(allocations.reduce((sum, a) => sum + a.totalHours, 0).toFixed(2))}h
       </div>
     </div>
   );
@@ -1182,7 +1182,7 @@ function ProjectRow({
                         className="absolute inset-0.5 flex items-center justify-center rounded text-xs font-semibold text-white"
                         style={{ backgroundColor: project.color }}
                       >
-                        {dayHours % 1 === 0 ? dayHours : dayHours.toFixed(1)}
+                        {dayHours % 1 === 0 ? dayHours : parseFloat(dayHours.toFixed(2))}
                       </div>
                     )}
                   </div>
@@ -1210,7 +1210,7 @@ function ProjectRow({
 
         {/* Total Hours */}
         <div className="text-dark-300 w-16 shrink-0 px-2 text-right text-sm">
-          {project.totalHours > 0 && `${project.totalHours.toFixed(1)}h`}
+          {project.totalHours > 0 && `${parseFloat(project.totalHours.toFixed(2))}h`}
         </div>
       </div>
 

--- a/src/components/plan/PlanResourceModal.tsx
+++ b/src/components/plan/PlanResourceModal.tsx
@@ -470,7 +470,7 @@ export function PlanResourceModal({
                     onChange={(e) => handleDayHoursChange(dateKey, e.target.value)}
                     min="0"
                     max="24"
-                    step="0.5"
+                    step="0.25"
                     disabled={isLoadingExisting}
                     className={`border-dark-600 bg-dark-700 text-dark-100 focus:ring-knowall-green h-8 w-full [appearance:textfield] rounded border px-1 text-right text-sm focus:ring-1 focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none ${hasExistingLine ? 'border-knowall-green/50' : ''}`}
                     placeholder="0"
@@ -496,7 +496,7 @@ export function PlanResourceModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{totalHours.toFixed(1)}h</span>
+          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/PlanResourceModal.tsx
+++ b/src/components/plan/PlanResourceModal.tsx
@@ -7,6 +7,7 @@ import { Modal, Button, Select } from '@/components/ui';
 import { useProjectsStore, useCompanyStore } from '@/hooks';
 import { bcClient } from '@/services/bc/bcClient';
 import { getBCResourceUrl, getBCJobUrl } from '@/utils/bcUrls';
+import { formatHours } from '@/utils';
 import { ResourceWorkload } from './ResourceWorkload';
 import type { SelectOption, BCResource } from '@/types';
 import { format, getWeek, startOfWeek, endOfWeek, eachDayOfInterval } from 'date-fns';
@@ -496,7 +497,7 @@ export function PlanResourceModal({
         {/* Total */}
         <div className="text-dark-300 border-dark-700 flex items-center justify-between border-t pt-3 text-sm">
           <span>Total Hours</span>
-          <span className="text-dark-100 font-medium">{parseFloat(totalHours.toFixed(2))}h</span>
+          <span className="text-dark-100 font-medium">{formatHours(totalHours)}h</span>
         </div>
 
         {/* Actions */}

--- a/src/components/plan/ResourceWorkload.tsx
+++ b/src/components/plan/ResourceWorkload.tsx
@@ -176,7 +176,7 @@ export function ResourceWorkload({
         </div>
         {hasLoaded && (
           <span className="text-dark-400 text-xs">
-            {weeklyTotal.toFixed(1)}h / {DAILY_CAPACITY * 5}h this business week
+            {parseFloat(weeklyTotal.toFixed(2))}h / {DAILY_CAPACITY * 5}h this business week
           </span>
         )}
       </button>
@@ -244,7 +244,7 @@ export function ResourceWorkload({
                             : 'text-dark-400'
                         )}
                       >
-                        {combined.hours > 0 ? `${combined.hours.toFixed(1)}h` : '-'}
+                        {combined.hours > 0 ? `${parseFloat(combined.hours.toFixed(2))}h` : '-'}
                       </span>
                     </div>
                   );
@@ -276,11 +276,11 @@ export function ResourceWorkload({
                         </td>
                         {dateKeys.map((date) => (
                           <td key={date} className="py-0.5 text-right">
-                            {proj.days[date] ? proj.days[date].toFixed(1) : '-'}
+                            {proj.days[date] ? parseFloat(proj.days[date].toFixed(2)) : '-'}
                           </td>
                         ))}
                         <td className="text-dark-200 py-0.5 text-right font-medium">
-                          {proj.total.toFixed(1)}
+                          {parseFloat(proj.total.toFixed(2))}
                         </td>
                       </tr>
                     ))}
@@ -309,7 +309,7 @@ export function ResourceWorkload({
                                 : 'text-emerald-400'
                         )}
                       >
-                        {isWeekend ? '-' : `${available.toFixed(1)}h`}
+                        {isWeekend ? '-' : `${parseFloat(available.toFixed(2))}h`}
                       </span>
                       <span className="text-dark-500 text-[10px]">avail</span>
                     </div>

--- a/src/components/plan/ResourceWorkload.tsx
+++ b/src/components/plan/ResourceWorkload.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
-import { cn } from '@/utils/cn';
+import { cn, formatHours } from '@/utils';
 import { useProjectsStore } from '@/hooks';
 import { bcClient } from '@/services/bc/bcClient';
 import type { BCJobPlanningLine } from '@/types';
@@ -176,7 +176,7 @@ export function ResourceWorkload({
         </div>
         {hasLoaded && (
           <span className="text-dark-400 text-xs">
-            {parseFloat(weeklyTotal.toFixed(2))}h / {DAILY_CAPACITY * 5}h this business week
+            {formatHours(weeklyTotal)}h / {DAILY_CAPACITY * 5}h this business week
           </span>
         )}
       </button>
@@ -244,7 +244,7 @@ export function ResourceWorkload({
                             : 'text-dark-400'
                         )}
                       >
-                        {combined.hours > 0 ? `${parseFloat(combined.hours.toFixed(2))}h` : '-'}
+                        {combined.hours > 0 ? `${formatHours(combined.hours)}h` : '-'}
                       </span>
                     </div>
                   );
@@ -276,11 +276,11 @@ export function ResourceWorkload({
                         </td>
                         {dateKeys.map((date) => (
                           <td key={date} className="py-0.5 text-right">
-                            {proj.days[date] ? parseFloat(proj.days[date].toFixed(2)) : '-'}
+                            {proj.days[date] ? formatHours(proj.days[date]) : '-'}
                           </td>
                         ))}
                         <td className="text-dark-200 py-0.5 text-right font-medium">
-                          {parseFloat(proj.total.toFixed(2))}
+                          {formatHours(proj.total)}
                         </td>
                       </tr>
                     ))}
@@ -309,7 +309,7 @@ export function ResourceWorkload({
                                 : 'text-emerald-400'
                         )}
                       >
-                        {isWeekend ? '-' : `${parseFloat(available.toFixed(2))}h`}
+                        {isWeekend ? '-' : `${formatHours(available)}h`}
                       </span>
                       <span className="text-dark-500 text-[10px]">avail</span>
                     </div>

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -113,3 +113,13 @@ export function isResourceDayBased(
   const hourFactor = uomConversionMap.get(hourKey);
   return hourFactor !== undefined && hourFactor > 0 && hourFactor !== 1;
 }
+
+/**
+ * Format hours for display, stripping unnecessary trailing zeros.
+ * Supports 15-minute (0.25h) increments.
+ *
+ * Examples: 1.00 → "1", 0.50 → "0.5", 0.25 → "0.25", 8.75 → "8.75"
+ */
+export function formatHours(hours: number): string {
+  return parseFloat(hours.toFixed(2)).toString();
+}


### PR DESCRIPTION
## Summary
- Change `step` attribute from `0.5` to `0.25` on all Plan modal hours inputs (PlanEntryModal, PlanEditModal, PlanResourceModal)
- Update rounding logic from nearest 0.5 (`* 2 / 2`) to nearest 0.25 (`* 4 / 4`)
- Fix display formatting across PlanPanel and ResourceWorkload to show quarter-hour values correctly (e.g., 0.25 instead of 0.3)
<img width="1450" height="285" alt="image" src="https://github.com/user-attachments/assets/e669c62f-874d-4ff3-81b6-19828f2cce07" />

Fixes #183

## Test plan
- [x] Enter 0.25h in Add Plan modal — accepted without validation error
- [x] Enter 0.75h in Add Plan modal — accepted without validation error
- [x] Edit existing plan entry — values display correctly (not rounded to 0.5)
- [x] Grid cells show correct values (0.25, 0.75 etc.)
- [x] Totals display correctly without trailing zeros

🤖 Generated with [Claude Code](https://claude.com/claude-code)