### PR TITLE
fix: Add UOM conversion to PlanResourceModal and ResourceWorkload

### DIFF
--- a/src/components/plan/PlanEditModal.tsx
+++ b/src/components/plan/PlanEditModal.tsx
@@ -451,6 +451,7 @@ export function PlanEditModal({
             excludeJobNo={allocation.projectNumber}
             excludeJobTaskNo={allocation.taskNumber}
             currentDayHours={hoursPerDay}
+            uomMap={uomMap}
           />
         )}
 

--- a/src/components/plan/PlanEntryModal.tsx
+++ b/src/components/plan/PlanEntryModal.tsx
@@ -167,9 +167,9 @@ export function PlanEntryModal({
           // Track id and etag for updates (last one wins if multiple)
           newLinesByDate[dateKey] = { id: line.id, etag: line['@odata.etag'] || '' };
         }
-        // Round each date's total once
+        // Round each date's total once to the existing 0.5-hour granularity
         for (const [dateKey, total] of Object.entries(rawHours)) {
-          const rounded = Math.round(total * 4) / 4;
+          const rounded = Math.round(total * 2) / 2;
           newHours[dateKey] = rounded.toString();
         }
 

--- a/src/components/plan/PlanEntryModal.tsx
+++ b/src/components/plan/PlanEntryModal.tsx
@@ -157,17 +157,20 @@ export function PlanEntryModal({
         });
 
         // Fill in existing values (convert base unit to hours for display)
+        // Sum all raw hours per date first, then round once to avoid cumulative drift
+        const rawHours: Record<string, number> = {};
         for (const line of existingLines) {
           const dateKey = line.planningDate;
           // Convert from resource's base unit to hours
           const hoursValue = convertToHours(resourceNumber, line.quantity, uomMap);
-          // If there are multiple lines for the same day, sum them
-          const existingVal = parseFloat(newHours[dateKey] || '0');
-          // Round to nearest 0.5 hour
-          const rounded = Math.round((existingVal + hoursValue) * 2) / 2;
-          newHours[dateKey] = rounded.toString();
+          rawHours[dateKey] = (rawHours[dateKey] || 0) + hoursValue;
           // Track id and etag for updates (last one wins if multiple)
           newLinesByDate[dateKey] = { id: line.id, etag: line['@odata.etag'] || '' };
+        }
+        // Round each date's total once
+        for (const [dateKey, total] of Object.entries(rawHours)) {
+          const rounded = Math.round(total * 4) / 4;
+          newHours[dateKey] = rounded.toString();
         }
 
         setDayHours(newHours);
@@ -525,6 +528,7 @@ export function PlanEntryModal({
             excludeJobNo={excludeJobNo}
             excludeJobTaskNo={excludeJobTaskNo}
             currentDayHours={dayHours}
+            uomMap={uomMap}
           />
         )}
 

--- a/src/components/plan/PlanResourceModal.tsx
+++ b/src/components/plan/PlanResourceModal.tsx
@@ -7,6 +7,13 @@ import { Modal, Button, Select } from '@/components/ui';
 import { useProjectsStore, useCompanyStore } from '@/hooks';
 import { bcClient } from '@/services/bc/bcClient';
 import { getBCResourceUrl, getBCJobUrl } from '@/utils/bcUrls';
+import {
+  buildUOMConversionMap,
+  convertToHours,
+  convertFromHours,
+  type UOMConversionMap,
+} from '@/utils';
+import { usePlanStore } from '@/hooks/usePlanStore';
 import { ResourceWorkload } from './ResourceWorkload';
 import type { SelectOption, BCResource } from '@/types';
 import { format, getWeek, startOfWeek, endOfWeek, eachDayOfInterval } from 'date-fns';
@@ -34,8 +41,11 @@ export function PlanResourceModal({
 }: PlanResourceModalProps) {
   const { projects, fetchProjects } = useProjectsStore();
   const { selectedCompany } = useCompanyStore();
+  const cachedUomMap = usePlanStore((s) => s.uomConversionMap);
 
   const [resources, setResources] = useState<BCResource[]>([]);
+  // UOM conversion map for converting between hours and resource base units
+  const [uomMap, setUomMap] = useState<UOMConversionMap>(new Map());
   const [resourceId, setResourceId] = useState('');
   const [taskId, setTaskId] = useState('');
   const [dayHours, setDayHours] = useState<Record<string, string>>({});
@@ -64,12 +74,25 @@ export function PlanResourceModal({
     [projects, projectNumber]
   );
 
-  // Check if BC extension is installed
+  // Check if BC extension is installed and load UOM data
   useEffect(() => {
     if (isOpen) {
       bcClient.isExtensionInstalled().then(setExtensionInstalled);
+      // Use cached UOM map from plan store if available, otherwise fetch
+      if (cachedUomMap.size > 0) {
+        setUomMap(cachedUomMap);
+      } else {
+        bcClient
+          .getResourceUnitsOfMeasure()
+          .then((resourceUOMs) => {
+            setUomMap(buildUOMConversionMap(resourceUOMs));
+          })
+          .catch(() => {
+            setUomMap(new Map());
+          });
+      }
     }
-  }, [isOpen]);
+  }, [isOpen, cachedUomMap]);
 
   // Fetch resources and projects when modal opens
   useEffect(() => {
@@ -143,12 +166,13 @@ export function PlanResourceModal({
           newHours[dateKey] = '';
         });
 
-        // Fill in existing values
+        // Fill in existing values (convert base unit to hours for display)
         for (const line of existingLines) {
           const dateKey = line.planningDate;
+          const hoursValue = convertToHours(resourceId, line.quantity, uomMap);
           // If there are multiple lines for the same day, sum them
           const existingVal = parseFloat(newHours[dateKey] || '0');
-          newHours[dateKey] = (existingVal + line.quantity).toString();
+          newHours[dateKey] = (existingVal + hoursValue).toString();
           // Track id and etag for updates (last one wins if multiple)
           newLinesByDate[dateKey] = { id: line.id, etag: line['@odata.etag'] || '' };
         }
@@ -172,7 +196,7 @@ export function PlanResourceModal({
     } finally {
       setIsLoadingExisting(false);
     }
-  }, [resourceId, taskId, currentProject, projectNumber, weekStart, weekEnd, weekDays]);
+  }, [resourceId, taskId, currentProject, projectNumber, weekStart, weekEnd, weekDays, uomMap]);
 
   // Trigger fetch when both resource and task are selected
   useEffect(() => {
@@ -282,26 +306,28 @@ export function PlanResourceModal({
         deleted++;
       }
 
-      // Update existing lines
+      // Update existing lines (convert hours to resource base unit)
       for (const item of toUpdate) {
+        const quantityInBaseUnit = convertFromHours(resourceId, item.hours, uomMap);
         await bcClient.updateJobPlanningLine(
           item.id,
           {
-            quantity: item.hours,
+            quantity: quantityInBaseUnit,
           },
           item.etag
         );
         updated++;
       }
 
-      // Create new lines
+      // Create new lines (convert hours to resource base unit)
       for (const item of toCreate) {
+        const quantityInBaseUnit = convertFromHours(resourceId, item.hours, uomMap);
         await bcClient.createJobPlanningLine({
           jobNo: projectNumber,
           jobTaskNo: task.code,
           resourceNo: resourceId,
           planningDate: item.date,
-          quantity: item.hours,
+          quantity: quantityInBaseUnit,
         });
         created++;
       }
@@ -490,6 +516,7 @@ export function PlanResourceModal({
             excludeJobNo={projectNumber}
             excludeJobTaskNo={excludeJobTaskNo}
             currentDayHours={dayHours}
+            uomMap={uomMap}
           />
         )}
 

--- a/src/components/plan/ResourceWorkload.tsx
+++ b/src/components/plan/ResourceWorkload.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { cn } from '@/utils/cn';
+import { convertToHours, type UOMConversionMap } from '@/utils';
 import { useProjectsStore } from '@/hooks';
 import { bcClient } from '@/services/bc/bcClient';
 import type { BCJobPlanningLine } from '@/types';
@@ -18,6 +19,8 @@ interface ResourceWorkloadProps {
   excludeJobTaskNo?: string;
   /** Current form hours (date key → string value) to reflect in bars live */
   currentDayHours?: Record<string, string>;
+  /** UOM conversion map for converting quantities to hours */
+  uomMap?: UOMConversionMap;
 }
 
 interface DayAllocation {
@@ -39,6 +42,7 @@ export function ResourceWorkload({
   excludeJobNo,
   excludeJobTaskNo,
   currentDayHours,
+  uomMap = new Map(),
 }: ResourceWorkloadProps) {
   const { projects } = useProjectsStore();
   const [isExpanded, setIsExpanded] = useState(true);
@@ -98,15 +102,15 @@ export function ResourceWorkload({
     });
   }, [lines, excludeJobNo, excludeJobTaskNo]);
 
-  // Aggregate hours per day
+  // Aggregate hours per day (convert from resource base unit)
   const dailyAllocations: DayAllocation[] = useMemo(() => {
     return dateKeys.map((date) => {
       const hours = filteredLines
         .filter((l) => l.planningDate === date)
-        .reduce((sum, l) => sum + l.quantity, 0);
+        .reduce((sum, l) => sum + convertToHours(resourceNo, l.quantity, uomMap), 0);
       return { date, hours };
     });
-  }, [dateKeys, filteredLines]);
+  }, [dateKeys, filteredLines, resourceNo, uomMap]);
 
   // Combined total per day (other workload + current form hours)
   const combinedDailyHours: DayAllocation[] = useMemo(() => {
@@ -139,12 +143,13 @@ export function ResourceWorkload({
         });
       }
       const entry = map.get(key)!;
-      entry.days[line.planningDate] = (entry.days[line.planningDate] || 0) + line.quantity;
-      entry.total += line.quantity;
+      const hours = convertToHours(resourceNo, line.quantity, uomMap);
+      entry.days[line.planningDate] = (entry.days[line.planningDate] || 0) + hours;
+      entry.total += hours;
     }
 
     return Array.from(map.values()).sort((a, b) => b.total - a.total);
-  }, [filteredLines, projects]);
+  }, [filteredLines, projects, resourceNo, uomMap]);
 
   // Color for capacity bar
   const getBarColor = (hours: number) => {


### PR DESCRIPTION
## Summary
- **PlanResourceModal (#186)**: Add UOM conversion when loading/saving planning lines, matching PlanEntryModal and PlanEditModal. DAY-based resources now display and persist correct hour values.
- **ResourceWorkload (#185)**: Accept `uomMap` prop and convert `line.quantity` to hours before aggregating. Fixes incorrect capacity/workload display for DAY-based resources.
- **PlanEntryModal (#187)**: Sum all raw hours per date first, then round once — prevents cumulative drift when multiple lines exist for the same day.

Fixes #185, #186, #187

## Test plan
- [x] Open PlanResourceModal for a DAY-based resource — hours should display correctly
- [x] Save planning lines via PlanResourceModal — quantities saved in correct base unit
- [x] ResourceWorkload capacity bars show correct hours for DAY-based resources
- [x] PlanEntryModal with multiple lines per day shows correctly summed/rounded values
- [x] HOUR-based resources continue to work as before (no conversion needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)