### PR TITLE
fix: Use BC resources directly for teammate timesheet view (#189)

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -25,7 +25,7 @@ export function Dashboard() {
               <h1 className="text-2xl font-bold text-white">Timesheet</h1>
               <p className="text-dark-400 mt-1">
                 {isViewingTeammate
-                  ? `Viewing ${selectedTeammate.displayName}'s timesheet`
+                  ? `Viewing ${selectedTeammate.name || selectedTeammate.displayName || selectedTeammate.number}'s timesheet`
                   : 'Track your time and sync to Business Central'}
               </p>
             </div>

--- a/src/components/timesheet/TeammateSelector.tsx
+++ b/src/components/timesheet/TeammateSelector.tsx
@@ -11,7 +11,18 @@ import {
 import { useTeammateStore, useCompanyStore } from '@/hooks';
 import { useAuth } from '@/services/auth';
 import { cn } from '@/utils';
-import type { BCEmployee } from '@/types';
+import { bcClient } from '@/services/bc';
+import type { BCResource } from '@/types';
+
+// Resources expose `name` (and sometimes `displayName`); pick the best label.
+function teammateLabel(t: BCResource): string {
+  return t.name || t.displayName || t.number;
+}
+
+function teammateInitial(t: BCResource): string {
+  const label = teammateLabel(t);
+  return label?.[0] || '?';
+}
 
 export function TeammateSelector() {
   const [isOpen, setIsOpen] = useState(false);
@@ -52,31 +63,32 @@ export function TeammateSelector() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen]);
 
-  const handleSelect = (teammate: BCEmployee | null) => {
+  const handleSelect = (teammate: BCResource | null) => {
     selectTeammate(teammate);
     setIsOpen(false);
     setSearchQuery('');
   };
 
-  // Filter teammates by search query, excluding current user
+  // Filter teammates by search query
   const filteredTeammates = teammates.filter((teammate) => {
-    // Filter by search
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
-      const matchesName = teammate.displayName.toLowerCase().includes(query);
-      const matchesEmail = teammate.email?.toLowerCase().includes(query);
-      if (!matchesName && !matchesEmail) return false;
+      const matchesName = teammateLabel(teammate).toLowerCase().includes(query);
+      const matchesUserId = teammate.timeSheetOwnerUserId?.toLowerCase().includes(query);
+      const matchesNumber = teammate.number.toLowerCase().includes(query);
+      if (!matchesName && !matchesUserId && !matchesNumber) return false;
     }
     return true;
   });
 
-  // Separate current user from other teammates
-  const currentUserEmail = account?.username?.toLowerCase();
+  // Identify the current user's resource by deriving the BC User ID from their UPN
+  // (matches the convention used in bcClient.deriveBCUserId).
+  const currentUserBCId = account?.username ? bcClient.deriveBCUserId(account.username) : undefined;
   const currentUserTeammate = filteredTeammates.find(
-    (t) => t.email?.toLowerCase() === currentUserEmail
+    (t) => t.timeSheetOwnerUserId?.toUpperCase() === currentUserBCId
   );
   const otherTeammates = filteredTeammates.filter(
-    (t) => t.email?.toLowerCase() !== currentUserEmail
+    (t) => t.timeSheetOwnerUserId?.toUpperCase() !== currentUserBCId
   );
 
   // Don't show if no teammates available (only self)
@@ -84,7 +96,7 @@ export function TeammateSelector() {
     return null;
   }
 
-  const displayName = selectedTeammate ? selectedTeammate.displayName : 'My Timesheet';
+  const displayName = selectedTeammate ? teammateLabel(selectedTeammate) : 'My Timesheet';
 
   return (
     <div className="relative" ref={dropdownRef}>
@@ -160,7 +172,7 @@ export function TeammateSelector() {
                       <span className="text-dark-200">My Timesheet</span>
                       {currentUserTeammate && (
                         <span className="text-dark-400 ml-2 text-xs">
-                          ({currentUserTeammate.displayName})
+                          ({teammateLabel(currentUserTeammate)})
                         </span>
                       )}
                     </div>
@@ -198,19 +210,11 @@ export function TeammateSelector() {
                           aria-selected={isSelected}
                         >
                           <div className="bg-dark-600 text-dark-200 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium">
-                            {teammate.givenName?.[0] ||
-                              teammate.surname?.[0] ||
-                              teammate.displayName?.[0] ||
-                              '?'}
-                            {teammate.givenName?.[0] && teammate.surname?.[0]
-                              ? teammate.surname[0]
-                              : ''}
+                            {teammateInitial(teammate)}
                           </div>
                           <div className="flex-1 truncate">
-                            <div className="text-dark-200">{teammate.displayName}</div>
-                            {teammate.jobTitle && (
-                              <div className="text-dark-400 text-xs">{teammate.jobTitle}</div>
-                            )}
+                            <div className="text-dark-200">{teammateLabel(teammate)}</div>
+                            <div className="text-dark-400 text-xs">{teammate.number}</div>
                           </div>
                           {isSelected && (
                             <CheckIcon className="text-knowall-green h-5 w-5 flex-shrink-0" />

--- a/src/components/timesheet/WeeklyTimesheet.tsx
+++ b/src/components/timesheet/WeeklyTimesheet.tsx
@@ -445,12 +445,12 @@ Thank you!`)}`}
             <div className="flex-1">
               <span className="text-dark-200 text-sm">
                 Viewing{' '}
-                <span className="font-medium text-white">{selectedTeammate.displayName}</span>
+                <span className="font-medium text-white">
+                  {selectedTeammate.name || selectedTeammate.displayName || selectedTeammate.number}
+                </span>
                 &apos;s timesheet
               </span>
-              {selectedTeammate.jobTitle && (
-                <span className="text-dark-400 ml-2 text-xs">({selectedTeammate.jobTitle})</span>
-              )}
+              <span className="text-dark-400 ml-2 text-xs">({selectedTeammate.number})</span>
             </div>
             <span className="bg-thyme-600/20 text-thyme-400 rounded px-2 py-1 text-xs">
               Read-only
@@ -623,7 +623,11 @@ Thank you!`)}`}
               {isViewingTeammate ? (
                 <>
                   <p className="text-dark-300 mb-2">
-                    No time entries found for {selectedTeammate.displayName} this week.
+                    No time entries found for{' '}
+                    {selectedTeammate.name ||
+                      selectedTeammate.displayName ||
+                      selectedTeammate.number}{' '}
+                    this week.
                   </p>
                   <p className="text-dark-500 text-sm">
                     Time entries will appear here once added to their timesheet.

--- a/src/hooks/useTeammateStore.ts
+++ b/src/hooks/useTeammateStore.ts
@@ -1,15 +1,15 @@
 import { create } from 'zustand';
-import type { BCEmployee } from '@/types';
+import type { BCResource } from '@/types';
 import { bcClient } from '@/services/bc/bcClient';
 
 interface TeammateStore {
-  teammates: BCEmployee[];
-  selectedTeammate: BCEmployee | null;
+  teammates: BCResource[];
+  selectedTeammate: BCResource | null;
   isLoading: boolean;
   error: string | null;
 
   fetchTeammates: () => Promise<void>;
-  selectTeammate: (teammate: BCEmployee | null) => void;
+  selectTeammate: (teammate: BCResource | null) => void;
   clearSelection: () => void;
   isViewingTeammate: () => boolean;
 }
@@ -23,15 +23,19 @@ export const useTeammateStore = create<TeammateStore>((set, get) => ({
   fetchTeammates: async () => {
     set({ isLoading: true, error: null });
     try {
-      const employees = await bcClient.getEmployees("status eq 'Active'");
-      set({ teammates: employees, isLoading: false });
+      // Resources are the entities that own timesheets, so look them up directly
+      // (employees -> resources mapping is unreliable in BC).
+      const resources = await bcClient.getResources();
+      // Only show resources that actually use timesheets — others have nothing to display.
+      const withTimesheet = resources.filter((r) => r.useTimeSheet);
+      set({ teammates: withTimesheet, isLoading: false });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to fetch teammates';
       set({ error: message, isLoading: false, teammates: [] });
     }
   },
 
-  selectTeammate: (teammate: BCEmployee | null) => {
+  selectTeammate: (teammate: BCResource | null) => {
     set({ selectedTeammate: teammate });
   },
 

--- a/src/hooks/useTimeEntriesStore.ts
+++ b/src/hooks/useTimeEntriesStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { TimeEntry, WeekData, BCEmployee, BCTimeSheet, TimesheetDisplayStatus } from '@/types';
+import type { TimeEntry, WeekData, BCResource, BCTimeSheet, TimesheetDisplayStatus } from '@/types';
 import {
   timeEntryService,
   NoResourceError,
@@ -26,7 +26,7 @@ interface TimeEntriesStore {
 
   // Entry operations
   fetchWeekEntries: (userId: string, weekStart?: Date) => Promise<void>;
-  fetchTeammateEntries: (teammate: BCEmployee, weekStart?: Date) => Promise<void>;
+  fetchTeammateEntries: (teammate: BCResource, weekStart?: Date) => Promise<void>;
   addEntry: (
     entry: Omit<
       TimeEntry,
@@ -136,7 +136,7 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
     }
   },
 
-  fetchTeammateEntries: async (teammate: BCEmployee, weekStart?: Date) => {
+  fetchTeammateEntries: async (teammate: BCResource, weekStart?: Date) => {
     const week = weekStart || get().currentWeekStart;
     set({ isLoading: true, error: null, currentWeekStart: week });
 

--- a/src/services/bc/timeEntryService.ts
+++ b/src/services/bc/timeEntryService.ts
@@ -5,7 +5,7 @@ import type {
   BCTimeSheet,
   BCTimeSheetLine,
   BCTimeSheetDetail,
-  BCEmployee,
+  BCResource,
 } from '@/types';
 import { format, startOfWeek } from 'date-fns';
 
@@ -578,17 +578,12 @@ export const timeEntryService = {
 
   /**
    * Get entries for a teammate from Business Central.
+   * The teammate is a BC Resource — we already have its number, so we can fetch
+   * the timesheet directly without an email→resource lookup.
    */
-  async getTeammateEntries(weekStart: Date, teammate: BCEmployee): Promise<TimeEntry[]> {
+  async getTeammateEntries(weekStart: Date, teammate: BCResource): Promise<TimeEntry[]> {
     try {
-      // Get resource by employee email
-      const resource = teammate.email ? await bcClient.getResourceByEmail(teammate.email) : null;
-
-      if (!resource) {
-        return [];
-      }
-
-      const timesheet = await this.getTimesheet(resource.number, weekStart);
+      const timesheet = await this.getTimesheet(teammate.number, weekStart);
       const [lines, details] = await Promise.all([
         bcClient.getTimeSheetLines(timesheet.number),
         bcClient.getAllTimeSheetDetails(timesheet.number),
@@ -596,13 +591,15 @@ export const timeEntryService = {
 
       return bcDataToTimeEntries(lines, details, timesheet, teammate.id);
     } catch (error) {
-      // Log error for debugging but don't expose to user
-      // This can fail for various reasons: no timesheet, no resource, network issues
+      // Common case: teammate has no timesheet for this week — return empty.
+      if (error instanceof NoTimesheetError) {
+        return [];
+      }
       if (process.env.NODE_ENV === 'development') {
         console.error('Failed to get teammate entries:', {
           weekStart,
           teammateId: teammate.id,
-          teammateEmail: teammate.email,
+          teammateNumber: teammate.number,
           error,
         });
       }


### PR DESCRIPTION
Closes #189

## Summary

- Teammate dropdown on the Time tab now fetches BC **resources** (where `useTimeSheet=true`) instead of employees — resources are the entities that own timesheets, so we can fetch them by `resource.number` directly.
- `getTeammateEntries` no longer relies on `getResourceByEmail`, which silently failed whenever an employee's email was missing or its local-part didn't match the resource's `timeSheetOwnerUserId` convention.
- Same pattern already used on the Team page (`TeamList.tsx`), so this brings the two views into agreement.

## Root cause

`getTeammateEntries` called `bcClient.getResourceByEmail(teammate.email)`, which forwards to `getResourceForCurrentUser`. That helper derives a BC User ID by uppercasing the part before `@` and filters resources by `timeSheetOwnerUserId`. It works for the logged-in user (their UPN follows the convention) but is unreliable for teammates pulled from `/employees`. When the lookup returned `null`, the function returned `[]` — the empty state seen in the bug report.

## Test plan

- [x] Type check passes (`bun run typecheck`)
- [x] Verified locally: own timesheet still loads
- [ ] Verify locally: selecting a teammate from the dropdown loads their timesheet entries
- [ ] Verify "(My Name)" still appears next to "My Timesheet" in the dropdown
- [ ] Verify dropdown hides when the user is the only resource with `useTimeSheet=true`

## Notes

- The teammate read-only banner now shows the resource `number` (BC code) instead of `jobTitle`, since `jobTitle` is an employee-only field.
- `getResourceByEmail` is still in `bcClient.ts` (used by `TeamList.tsx` for the current user's own resource); not removing it in this PR to keep the change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)