### PR TITLE
fix: hide archived/blocked projects from list, timer and time-entry dropdowns

### DIFF
--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -301,7 +301,7 @@ export function ProjectList({ onSelectProject }: ProjectListProps) {
                 onChange={(e) => setStatusFilter(e.target.value)}
                 className="w-40"
                 options={[
-                  { value: 'all', label: 'All Status' },
+                  { value: 'all', label: 'Active & Completed' },
                   ...uniqueStatuses.map((status) => ({
                     value: status,
                     label: status.charAt(0).toUpperCase() + status.slice(1),

--- a/src/components/projects/ProjectList.tsx
+++ b/src/components/projects/ProjectList.tsx
@@ -153,8 +153,10 @@ export function ProjectList({ onSelectProject }: ProjectListProps) {
       result = result.filter((p) => p.isFavorite);
     }
 
-    // Apply status filter
-    if (statusFilter !== 'all') {
+    // Apply status filter — hide archived by default
+    if (statusFilter === 'all') {
+      result = result.filter((p) => p.status !== 'archived');
+    } else {
       result = result.filter((p) => p.status === statusFilter);
     }
 

--- a/src/components/timer/StartTimerModal.tsx
+++ b/src/components/timer/StartTimerModal.tsx
@@ -41,7 +41,10 @@ export function StartTimerModal({ isOpen, onClose }: StartTimerModalProps) {
     }
   }, [isOpen, selectedProject]);
 
-  const projectOptions: SelectOption[] = projects.map((p) => ({
+  // Only show active projects for timer (exclude archived and completed)
+  const activeProjects = projects.filter((p) => p.status === 'active');
+
+  const projectOptions: SelectOption[] = activeProjects.map((p) => ({
     value: p.id,
     label: `${p.code} - ${p.name}`,
   }));

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -63,10 +63,25 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
     }
   }, [isOpen]);
 
-  // Get unique customers from projects
+  // Available projects for selection in this modal: active projects only,
+  // plus the entry's current project if editing — so reopening an entry
+  // logged against a project that has since been archived still shows the
+  // original selection. Customer/project dropdowns both derive from this.
+  const availableProjects = useMemo(() => {
+    const result = projects.filter((p) => p.status === 'active');
+    if (entry) {
+      const entryProject = projects.find((p) => p.code === entry.projectId);
+      if (entryProject && entryProject.status !== 'active') {
+        result.push(entryProject);
+      }
+    }
+    return result;
+  }, [projects, entry]);
+
+  // Get unique customers from available projects
   const customerOptions: SelectOption[] = useMemo(() => {
     const customers = new Map<string, string>();
-    projects.forEach((p) => {
+    availableProjects.forEach((p) => {
       const customerName = (p.customerName || 'Unknown').trim();
       const normalizedKey = customerName.toLowerCase();
       // Use the first occurrence's display name, but dedupe by normalized key
@@ -77,30 +92,28 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
     return Array.from(customers.values())
       .sort()
       .map((name) => ({ value: name, label: name }));
-  }, [projects]);
+  }, [availableProjects]);
 
   // Check if we should show customer dropdown (hide if only one customer or all "Unknown")
   const showCustomerDropdown =
     customerOptions.length > 1 ||
     (customerOptions.length === 1 && customerOptions[0].value !== 'Unknown');
 
-  // Filter projects by selected customer (or show all if customer dropdown is hidden)
-  // Only show active projects for time entry (exclude archived and completed)
+  // Filter available projects by selected customer (or show all if customer dropdown is hidden)
   const filteredProjects = useMemo(() => {
-    const activeProjects = projects.filter((p) => p.status === 'active');
     if (!showCustomerDropdown) {
-      return activeProjects;
+      return availableProjects;
     }
     if (!customerId) {
       return [];
     }
     // Use case-insensitive, trimmed comparison for robustness
     const normalizedCustomerId = customerId.trim().toLowerCase();
-    return activeProjects.filter((p) => {
+    return availableProjects.filter((p) => {
       const projectCustomer = (p.customerName || 'Unknown').trim().toLowerCase();
       return projectCustomer === normalizedCustomerId;
     });
-  }, [projects, customerId, showCustomerDropdown]);
+  }, [availableProjects, customerId, showCustomerDropdown]);
 
   // Helper to find the matching customerOption value for a customer name
   // This ensures the Select dropdown value matches exactly

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -74,16 +74,18 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
     (customerOptions.length === 1 && customerOptions[0].value !== 'Unknown');
 
   // Filter projects by selected customer (or show all if customer dropdown is hidden)
+  // Only show active projects for time entry (exclude archived and completed)
   const filteredProjects = useMemo(() => {
+    const activeProjects = projects.filter((p) => p.status === 'active');
     if (!showCustomerDropdown) {
-      return projects;
+      return activeProjects;
     }
     if (!customerId) {
       return [];
     }
     // Use case-insensitive, trimmed comparison for robustness
     const normalizedCustomerId = customerId.trim().toLowerCase();
-    return projects.filter((p) => {
+    return activeProjects.filter((p) => {
       const projectCustomer = (p.customerName || 'Unknown').trim().toLowerCase();
       return projectCustomer === normalizedCustomerId;
     });

--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -5,6 +5,7 @@ import type {
   BCEnvironmentType,
   BCJob,
   BCProject,
+  BCStandardProject,
   BCCustomer,
   BCEmployee,
   BCJobTask,
@@ -370,6 +371,25 @@ class BusinessCentralClient {
 
   async getProject(projectId: string): Promise<BCProject> {
     return this.fetchCustomApi<BCProject>(`/projects(${projectId})`);
+  }
+
+  /**
+   * Fetch blocked project numbers from the standard BC v2.0 API.
+   * The standard /projects endpoint exposes the 'blocked' enum field
+   * which the Thyme BC Extension may not include.
+   * Returns a Set of project numbers that are blocked.
+   */
+  async getBlockedProjectNumbers(): Promise<Set<string>> {
+    try {
+      const filter = "blocked ne ' '";
+      const select = '$select=number,blocked';
+      const endpoint = `/projects?$filter=${encodeURIComponent(filter)}&${select}`;
+      const response = await this.fetch<PaginatedResponse<BCStandardProject>>(endpoint);
+      return new Set(response.value.map((p) => p.number));
+    } catch {
+      // If the standard API doesn't support this endpoint/filter, return empty set
+      return new Set();
+    }
   }
 
   // Customers

--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -5,7 +5,6 @@ import type {
   BCEnvironmentType,
   BCJob,
   BCProject,
-  BCStandardProject,
   BCCustomer,
   BCEmployee,
   BCJobTask,
@@ -44,6 +43,21 @@ const VALID_TIMESHEET_STATUSES = ['Open', 'Submitted', 'Rejected', 'Approved', '
 
 // Available environments to query
 const BC_ENVIRONMENTS: BCEnvironmentType[] = ['sandbox', 'production'];
+
+/**
+ * Normalize a BCProject coming off the OData wire.
+ *
+ * BC's OData JSON serializer encodes the leading-space enum value (`' '`,
+ * the "not blocked" sentinel) as the literal string `"_x0020_"`
+ * (XML schema escape for U+0020). Translate it back to a real space so
+ * downstream code can use the documented enum values.
+ */
+function normalizeBCProject(project: BCProject): BCProject {
+  if (project.blocked === ('_x0020_' as unknown as BCProject['blocked'])) {
+    return { ...project, blocked: ' ' };
+  }
+  return project;
+}
 
 class BusinessCentralClient {
   private _companyId: string;
@@ -366,30 +380,12 @@ class BusinessCentralClient {
       endpoint += `?$filter=${encodeURIComponent(filter)}`;
     }
     const response = await this.fetchCustomApi<PaginatedResponse<BCProject>>(endpoint);
-    return response.value;
+    return response.value.map(normalizeBCProject);
   }
 
   async getProject(projectId: string): Promise<BCProject> {
-    return this.fetchCustomApi<BCProject>(`/projects(${projectId})`);
-  }
-
-  /**
-   * Fetch blocked project numbers from the standard BC v2.0 API.
-   * The standard /projects endpoint exposes the 'blocked' enum field
-   * which the Thyme BC Extension may not include.
-   * Returns a Set of project numbers that are blocked.
-   */
-  async getBlockedProjectNumbers(): Promise<Set<string>> {
-    try {
-      const filter = "blocked ne ' '";
-      const select = '$select=number,blocked';
-      const endpoint = `/projects?$filter=${encodeURIComponent(filter)}&${select}`;
-      const response = await this.fetch<PaginatedResponse<BCStandardProject>>(endpoint);
-      return new Set(response.value.map((p) => p.number));
-    } catch {
-      // If the standard API doesn't support this endpoint/filter, return empty set
-      return new Set();
-    }
+    const project = await this.fetchCustomApi<BCProject>(`/projects(${projectId})`);
+    return normalizeBCProject(project);
   }
 
   // Customers

--- a/src/services/bc/projectDetailsService.ts
+++ b/src/services/bc/projectDetailsService.ts
@@ -143,8 +143,11 @@ export const projectDetailsService = {
    * Fetch project details and tasks by project number
    */
   async getProjectDetails(projectNumber: string): Promise<{ project: Project; tasks: Task[] }> {
-    // Fetch all projects and filter by number (the /jobs endpoint isn't available in all environments)
-    const bcProjects = await bcClient.getProjects();
+    // Fetch projects from extension API and blocked status from standard API in parallel
+    const [bcProjects, blockedNumbers] = await Promise.all([
+      bcClient.getProjects(),
+      bcClient.getBlockedProjectNumbers(),
+    ]);
     const bcProject = bcProjects.find((p) => p.number === projectNumber);
 
     if (!bcProject) {
@@ -158,9 +161,14 @@ export const projectDetailsService = {
     const startDate = bcProject.startingDate;
     const endDate = bcProject.endingDate;
 
-    // Map BC status to Thyme status
-    const status: 'active' | 'completed' =
-      bcProject.status === 'Completed' ? 'completed' : 'active';
+    // Map BC status to Thyme status — blocked projects are archived
+    // Merge blocked status from standard API (extension API may not expose it)
+    const isBlocked = bcProject.blocked || blockedNumbers.has(bcProject.number);
+    const status: Project['status'] = isBlocked
+      ? 'archived'
+      : bcProject.status === 'Completed'
+        ? 'completed'
+        : 'active';
 
     const project: Project = {
       id: bcProject.id,

--- a/src/services/bc/projectDetailsService.ts
+++ b/src/services/bc/projectDetailsService.ts
@@ -143,11 +143,7 @@ export const projectDetailsService = {
    * Fetch project details and tasks by project number
    */
   async getProjectDetails(projectNumber: string): Promise<{ project: Project; tasks: Task[] }> {
-    // Fetch projects from extension API and blocked status from standard API in parallel
-    const [bcProjects, blockedNumbers] = await Promise.all([
-      bcClient.getProjects(),
-      bcClient.getBlockedProjectNumbers(),
-    ]);
+    const bcProjects = await bcClient.getProjects();
     const bcProject = bcProjects.find((p) => p.number === projectNumber);
 
     if (!bcProject) {
@@ -162,8 +158,7 @@ export const projectDetailsService = {
     const endDate = bcProject.endingDate;
 
     // Map BC status to Thyme status — blocked projects are archived
-    // Merge blocked status from standard API (extension API may not expose it)
-    const isBlocked = bcProject.blocked || blockedNumbers.has(bcProject.number);
+    const isBlocked = bcProject.blocked && bcProject.blocked !== ' ';
     const status: Project['status'] = isBlocked
       ? 'archived'
       : bcProject.status === 'Completed'

--- a/src/services/bc/projectService.ts
+++ b/src/services/bc/projectService.ts
@@ -27,6 +27,27 @@ function getProjectColor(index: number): string {
   return PROJECT_COLORS[index % PROJECT_COLORS.length];
 }
 
+// Latch so the older-extension warning logs once per session.
+let warnedNoBlockedField = false;
+
+/**
+ * Warn (once per session) if no project in the response carries a `blocked`
+ * field. That signals the Thyme BC Extension is older than the version that
+ * exposes `blocked` on /projects, in which case archived projects will fall
+ * through to "active" and the hide-archived feature won't apply.
+ */
+function warnIfBlockedFieldMissing(bcProjects: BCProject[]): void {
+  if (warnedNoBlockedField || bcProjects.length === 0) return;
+  const anyHasBlocked = bcProjects.some((p) => p.blocked !== undefined);
+  if (!anyHasBlocked) {
+    warnedNoBlockedField = true;
+    console.warn(
+      '[Thyme] No project returned a `blocked` field. Archived projects will not be hidden — ' +
+        'install the latest Thyme BC Extension to enable the hide-archived feature.'
+    );
+  }
+}
+
 // The Thyme BC Extension API (v1.7+) returns displayName, billToCustomerName and status fields.
 
 function mapBCProjectToProject(bcProject: BCProject, index: number, favorites: string[]): Project {
@@ -77,6 +98,7 @@ function saveFavorites(favorites: string[]): void {
 export const projectService = {
   async getProjects(_includeCompleted = false): Promise<Project[]> {
     const bcProjects = await bcClient.getProjects();
+    warnIfBlockedFieldMissing(bcProjects);
     const favorites = getFavorites();
 
     return bcProjects.map((bcProject, index) => mapBCProjectToProject(bcProject, index, favorites));

--- a/src/services/bc/projectService.ts
+++ b/src/services/bc/projectService.ts
@@ -31,7 +31,8 @@ function getProjectColor(index: number): string {
 
 function mapBCProjectToProject(bcProject: BCProject, index: number, favorites: string[]): Project {
   // Map BC status to Thyme status — blocked projects are archived
-  const status: Project['status'] = bcProject.blocked
+  const isBlocked = bcProject.blocked && bcProject.blocked !== ' ';
+  const status: Project['status'] = isBlocked
     ? 'archived'
     : bcProject.status === 'Completed'
       ? 'completed'
@@ -75,19 +76,10 @@ function saveFavorites(favorites: string[]): void {
 
 export const projectService = {
   async getProjects(_includeCompleted = false): Promise<Project[]> {
-    // Fetch projects from extension API and blocked status from standard API in parallel
-    const [bcProjects, blockedNumbers] = await Promise.all([
-      bcClient.getProjects(),
-      bcClient.getBlockedProjectNumbers(),
-    ]);
+    const bcProjects = await bcClient.getProjects();
     const favorites = getFavorites();
 
-    return bcProjects.map((bcProject, index) => {
-      // Merge blocked status from standard API (extension API may not expose it)
-      const isBlocked = bcProject.blocked || blockedNumbers.has(bcProject.number);
-      const merged = { ...bcProject, blocked: isBlocked };
-      return mapBCProjectToProject(merged, index, favorites);
-    });
+    return bcProjects.map((bcProject, index) => mapBCProjectToProject(bcProject, index, favorites));
   },
 
   async getProject(projectId: string): Promise<Project | null> {

--- a/src/services/bc/projectService.ts
+++ b/src/services/bc/projectService.ts
@@ -30,8 +30,12 @@ function getProjectColor(index: number): string {
 // The Thyme BC Extension API (v1.7+) returns displayName, billToCustomerName and status fields.
 
 function mapBCProjectToProject(bcProject: BCProject, index: number, favorites: string[]): Project {
-  // Map BC status to Thyme status
-  const status: 'active' | 'completed' = bcProject.status === 'Completed' ? 'completed' : 'active';
+  // Map BC status to Thyme status — blocked projects are archived
+  const status: Project['status'] = bcProject.blocked
+    ? 'archived'
+    : bcProject.status === 'Completed'
+      ? 'completed'
+      : 'active';
 
   return {
     id: bcProject.id,
@@ -71,10 +75,19 @@ function saveFavorites(favorites: string[]): void {
 
 export const projectService = {
   async getProjects(_includeCompleted = false): Promise<Project[]> {
-    const bcProjects = await bcClient.getProjects();
+    // Fetch projects from extension API and blocked status from standard API in parallel
+    const [bcProjects, blockedNumbers] = await Promise.all([
+      bcClient.getProjects(),
+      bcClient.getBlockedProjectNumbers(),
+    ]);
     const favorites = getFavorites();
 
-    return bcProjects.map((bcProject, index) => mapBCProjectToProject(bcProject, index, favorites));
+    return bcProjects.map((bcProject, index) => {
+      // Merge blocked status from standard API (extension API may not expose it)
+      const isBlocked = bcProject.blocked || blockedNumbers.has(bcProject.number);
+      const merged = { ...bcProject, blocked: isBlocked };
+      return mapBCProjectToProject(merged, index, favorites);
+    });
   },
 
   async getProject(projectId: string): Promise<Project | null> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,9 +61,20 @@ export interface BCProject {
   billToCustomerNo?: string;
   billToCustomerName?: string;
   status?: 'Open' | 'Completed' | 'Planning';
+  blocked?: boolean;
   startingDate?: string;
   endingDate?: string;
   lastModifiedDateTime?: string;
+}
+
+// Standard BC v2.0 API project (from /projects endpoint)
+// Has the 'blocked' enum field that the extension API may not expose
+export interface BCStandardProject {
+  id: string;
+  number: string;
+  displayName: string;
+  blocked: ' ' | 'Posting' | 'All';
+  status?: 'Open' | 'Completed' | 'Planning';
 }
 
 export interface BCCustomer {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,20 +61,10 @@ export interface BCProject {
   billToCustomerNo?: string;
   billToCustomerName?: string;
   status?: 'Open' | 'Completed' | 'Planning';
-  blocked?: boolean;
+  blocked?: ' ' | 'Posting' | 'All';
   startingDate?: string;
   endingDate?: string;
   lastModifiedDateTime?: string;
-}
-
-// Standard BC v2.0 API project (from /projects endpoint)
-// Has the 'blocked' enum field that the extension API may not expose
-export interface BCStandardProject {
-  id: string;
-  number: string;
-  displayName: string;
-  blocked: ' ' | 'Posting' | 'All';
-  status?: 'Open' | 'Completed' | 'Planning';
 }
 
 export interface BCCustomer {


### PR DESCRIPTION
## Summary
- Maps BC's `blocked` enum to Thyme's `archived` status; hides archived projects from the project list by default and from the timer / time-entry dropdowns.
- Uses the `blocked` field exposed by the latest Thyme BC Extension on the `/projects` endpoint (no dual-API workaround).
- Normalises BC OData's `"_x0020_"` serialization of the not-blocked sentinel back to a real space at the boundary in `bcClient`, so downstream code can use the documented enum (`' ' | 'Posting' | 'All'`).
- Removes the now-redundant `BCStandardProject` type and `bcClient.getBlockedProjectNumbers()`.

## Requires
- The latest Thyme BC Extension installed in the target BC environment (older versions don't expose `blocked` on `/projects`).

## Test plan
- [x] Project list hides archived projects by default.
- [x] Selecting the "Archived" status filter shows them.
- [x] Start Timer modal: archived projects are not in the project dropdown.
- [x] Time Entry modal: archived projects are not in the project dropdown.
- [x] Project details page still loads correctly for non-archived projects.
- [ ] DevTools Network tab shows only one call to `/projects` (no dual-API merge).

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)