### PR TITLE
docs: clarify release flow and who can deploy what

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,39 @@
+<!--
+Title format: conventional-commit prefix + short description.
+  feat: ...      fix: ...      perf: ...      refactor: ...     (require Fixes #nnn)
+  chore: ...     ci: ...       docs: ...      deps: ...
+  test: ...      build: ...    style: ...
+
+Body: keep the sections below. Put each `Fixes #nnn` on its own line — one per
+issue. GitHub auto-closes those issues when this PR merges.
+-->
+
 ## Summary
 
-Brief description of the changes in this PR.
+<!-- 1–3 bullets: what changed and why. -->
 
-## Related Issue
+## Fixes
 
-Fixes #(issue number)
+Fixes #
 
-## Type of Change
+<!-- One `Fixes #nnn` per issue resolved. Delete this section for chore/ci/docs/deps PRs that aren't tied to an issue. -->
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Enhancement
-- [ ] Documentation update
-- [ ] Refactoring
+## Test plan
 
-## Changes Made
+<!--
+Step-by-step actions a reviewer or tester can follow, with expected results.
+Example:
+  1. Sign in with a Business Central account.
+  2. Open the Time Tracking page.
+  3. **Expected:** today's entries load without errors.
+  4. Add a new entry for project X, 30 minutes.
+  5. **Expected:** entry appears and totals update.
 
-- Change 1
-- Change 2
+For pure-refactor / docs / CI / deps PRs with no user-visible change, replace the steps with:
 
-## Testing
+  N/A — <one-line reason, e.g. "internal refactor, covered by existing tests">
+-->
 
-Describe how you tested these changes.
+## Screenshots (if applicable)
 
-## Checklist
-
-- [ ] I have run `npm run check` and all checks pass
-- [ ] My code follows the project's coding style
-- [ ] I have tested my changes locally
-- [ ] I have updated documentation if needed
+<!-- Add screenshots for visual changes. -->

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -31,7 +31,12 @@ jobs:
 
           fail=0
 
-          # 1. Title must use conventional-commit style:
+          # 1. Title must use a simplified prefix-only convention:
+          #    `<type>: <subject>`. Note this is intentionally narrower than
+          #    full Conventional Commits — scope (`feat(auth): ...`) and
+          #    breaking-change (`feat!: ...`) forms are NOT accepted, to keep
+          #    titles uniform across knowall-ai repos.
+          #
           #      feat: ...     (new feature, requires Fixes #nnn)
           #      fix: ...      (bug fix, requires Fixes #nnn)
           #      perf: ...     (perf improvement, requires Fixes #nnn)
@@ -41,7 +46,7 @@ jobs:
           #    A trailing "(#nnn)" or "(#nnn, #mmm)" reference is allowed but optional.
           title_regex='^(feat|fix|perf|refactor|chore|ci|docs|deps|test|build|style): .+'
           if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
-            echo "::error::PR title must start with a conventional-commit prefix:"
+            echo "::error::PR title must use one of these prefixes (no scope, no '!'):"
             echo "::error::  feat: ...     fix: ...     perf: ...     refactor: ..."
             echo "::error::  chore: ...    ci: ...      docs: ...     deps: ..."
             echo "::error::  test: ...     build: ...   style: ..."

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,98 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-lint:
+    name: Title, body and issue link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title, body and issue reference
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -u
+
+          # Bots open PRs without ticket refs / test plans — skip with success
+          # (exit 0 inside the step, not a job-level `if:`, so the check still
+          # reports "success" rather than "skipped" and can be required).
+          if [ "$GITHUB_ACTOR" = 'dependabot[bot]' ] || [ "$GITHUB_ACTOR" = 'github-actions[bot]' ]; then
+            echo "Skipping PR lint for bot actor: $GITHUB_ACTOR"
+            exit 0
+          fi
+
+          fail=0
+
+          # 1. Title must use conventional-commit style:
+          #      feat: ...     (new feature, requires Fixes #nnn)
+          #      fix: ...      (bug fix, requires Fixes #nnn)
+          #      perf: ...     (perf improvement, requires Fixes #nnn)
+          #      refactor: ... (no behaviour change, requires Fixes #nnn)
+          #    Bypass prefixes (Fixes line not required):
+          #      chore: ... | ci: ... | docs: ... | deps: ... | test: ... | build: ... | style: ...
+          #    A trailing "(#nnn)" or "(#nnn, #mmm)" reference is allowed but optional.
+          title_regex='^(feat|fix|perf|refactor|chore|ci|docs|deps|test|build|style): .+'
+          if ! echo "$PR_TITLE" | grep -Eq "$title_regex"; then
+            echo "::error::PR title must start with a conventional-commit prefix:"
+            echo "::error::  feat: ...     fix: ...     perf: ...     refactor: ..."
+            echo "::error::  chore: ...    ci: ...      docs: ...     deps: ..."
+            echo "::error::  test: ...     build: ...   style: ..."
+            echo "::error::Got: '$PR_TITLE'"
+            fail=1
+          fi
+
+          # 2. Body must not be empty and must be a meaningful length
+          body_len=$(echo -n "${PR_BODY:-}" | wc -c)
+          if [ "$body_len" -lt 40 ]; then
+            echo "::error::PR body is missing or too short (<40 chars). Describe what changed and why."
+            fail=1
+          fi
+
+          # 3. feat/fix/perf/refactor PRs must contain at least one 'Fixes #nnn' line.
+          #    Other prefixes (chore/ci/docs/deps/test/build/style) skip this check.
+          if echo "$PR_TITLE" | grep -Eq '^(feat|fix|perf|refactor): '; then
+            fixes_regex='^Fixes #[0-9]+'
+            if ! echo "$PR_BODY" | grep -Eq "$fixes_regex"; then
+              echo "::error::PR body must contain at least one 'Fixes #nnn' line for feat/fix/perf/refactor PRs."
+              echo "::error::Example:  Fixes #123"
+              echo "::error::This auto-closes the linked issue when the PR merges."
+              fail=1
+            fi
+          else
+            echo "Non-issue PR prefix detected — skipping 'Fixes #nnn' requirement."
+          fi
+
+          # 4. Body must include a Test plan section
+          if ! echo "$PR_BODY" | grep -Eq '^## Test plan'; then
+            echo "::error::PR body must include a '## Test plan' section."
+            echo "::error::Provide step-by-step tester actions, or 'N/A — <reason>' for pure refactor/docs/ci/deps."
+            fail=1
+          else
+            # The section must have non-template, non-empty content after it.
+            # Extract content after the heading up to the next heading or EOF, then
+            # strip both single-line and multi-line HTML comment blocks
+            # (perl -0pe with /s slurps the whole input so .*? spans newlines).
+            tp_content=$(echo "$PR_BODY" | awk '
+              /^## Test plan/ {intp=1; next}
+              /^## / {intp=0}
+              intp {print}
+            ' | perl -0pe 's/<!--.*?-->//gs' | tr -d '[:space:]')
+            if [ -z "$tp_content" ]; then
+              echo "::error::'## Test plan' section is empty or only contains the template comment."
+              echo "::error::Add steps or 'N/A — <reason>'."
+              fail=1
+            fi
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "PR lint passed."

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -181,6 +181,56 @@ git push && git push --tags
 
 The production deployment workflow triggers on release tags (`v*`), which builds and deploys to production with the new version number displayed in the footer.
 
+NOTE: `main` is protected and direct pushes are blocked for non-admins. The
+one-liner above only works for repository admins (who can bypass branch
+protection). Other contributors must release via a PR — see the next section.
+
+=== Releasing as a non-admin (via PR)
+
+Non-admin contributors cannot push the version-bump commit directly to `main`.
+The release flow becomes:
+
+[source,bash]
+----
+# 1. Branch and bump the version (creates a commit + tag locally)
+git switch -c release/v1.2.1
+npm version patch   # or minor / major
+
+# 2. Push the branch and open a PR for review
+git push -u origin release/v1.2.1
+gh pr create --fill
+
+# 3. After the PR is merged, push the tag from main
+git switch main && git pull --ff-only
+git push --tags
+----
+
+The tag push triggers the production deployment workflow, just as for the
+admin one-liner.
+
+=== Who can deploy what
+
+[cols="2,1,3"]
+|===
+| Action | Permission required | Notes
+
+| Deploy a PR to a staging slot (`slot1`–`slot4`)
+| Repo write
+| Run the *Deploy PR to Azure Slot* workflow from the Actions tab.
+
+| Bump version + push to `main` (admin one-liner)
+| Repo admin
+| Branch protection blocks the direct push for non-admins.
+
+| Push a `v*` tag to trigger production deploy
+| Repo write
+| Tags are not gated by branch protection. The tag must point at a commit that is already on `main`.
+
+| Approve a production deploy at the environment gate
+| Reviewer listed on the `production` environment
+| Currently no reviewers are configured — the workflow runs unattended once the tag is pushed.
+|===
+
 == PR Testing with Deployment Slots
 
 === Overview

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -192,17 +192,27 @@ The release flow becomes:
 
 [source,bash]
 ----
-# 1. Branch and bump the version (creates a commit + tag locally)
+# 1. Branch and bump the version in package.json only.
+#    --no-git-tag-version skips the commit + tag — we don't tag yet because
+#    the PR is likely to be squash- or rebase-merged, which rewrites the SHA
+#    and would leave any pre-created tag pointing at a commit that never
+#    lands on main.
 git switch -c release/v1.2.1
-npm version patch   # or minor / major
+npm version patch --no-git-tag-version   # or minor / major
 
-# 2. Push the branch and open a PR for review
+# 2. Commit the version bump and push the branch.
+git commit -am "chore: release v1.2.1"
 git push -u origin release/v1.2.1
-gh pr create --fill
 
-# 3. After the PR is merged, push the tag from main
+# 3. Open a PR for review and merge it via the normal flow.
+#    Either install the GitHub CLI (https://cli.github.com) and run:
+gh pr create --fill
+#    …or open the PR from the branch page in the GitHub web UI.
+
+# 4. After the PR is merged, tag the merge commit on main and push the tag.
 git switch main && git pull --ff-only
-git push --tags
+git tag v1.2.1
+git push origin v1.2.1
 ----
 
 The tag push triggers the production deployment workflow, just as for the
@@ -224,11 +234,11 @@ admin one-liner.
 
 | Push a `v*` tag to trigger production deploy
 | Repo write
-| Tags are not gated by branch protection. The tag must point at a commit that is already on `main`.
+| Tags are not gated by branch protection — anyone with write access can push *any* `v*` tag and trigger the production deploy. There is no enforcement that the tagged commit is reachable from `main`; team convention is to tag merge commits on `main` only.
 
-| Approve a production deploy at the environment gate
-| Reviewer listed on the `production` environment
-| Currently no reviewers are configured — the workflow runs unattended once the tag is pushed.
+| Approve a production deploy at an environment gate
+| (not configured)
+| `deploy-production.yml` does not declare `environment: production` on its job, so adding required reviewers to the `production` Actions environment would not currently pause the workflow. To add an approval gate, set `environment: production` on the deploy job and configure required reviewers.
 |===
 
 == PR Testing with Deployment Slots


### PR DESCRIPTION
## Summary

- Note that the documented `git push && git push --tags` release one-liner only works for repo **admins** — branch protection blocks the direct push for everyone else.
- Add a *Releasing as a non-admin (via PR)* section showing the branch-bump-merge-then-push-tag flow.
- Add a *Who can deploy what* table summarising the permissions for slot deploys, version bumps, tag pushes, and the (currently absent) production environment reviewer gate.

## Test plan

N/A — docs-only change.

---

### Notes

- This PR is blocked from merging until #196 lands, because branch protection now requires the `Title, body and issue link` check (added in #196). Suggest merging #196 first.
- Same release-flow stale guidance also lives in `CLAUDE.md`. Out of scope here, happy to do that as a follow-up.