### PR TITLE
feat: drag-and-drop entries across days and editable date in entry modal

### DIFF
--- a/src/components/timesheet/TimeEntryCell.tsx
+++ b/src/components/timesheet/TimeEntryCell.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type DragEvent } from 'react';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import type { TimeEntry, Project } from '@/types';
 import { cn, formatTime } from '@/utils';
+
+const DRAG_MIME_TYPE = 'application/x-thyme-entry-id';
 
 interface TimeEntryCellProps {
   entries: TimeEntry[];
@@ -12,6 +14,7 @@ interface TimeEntryCellProps {
   projects: Project[];
   onAddEntry: (date: string) => void;
   onEditEntry: (entry: TimeEntry) => void;
+  onMoveEntry?: (entryId: string, newDate: string) => void;
   readOnly?: boolean;
 }
 
@@ -22,9 +25,11 @@ export function TimeEntryCell({
   projects,
   onAddEntry,
   onEditEntry,
+  onMoveEntry,
   readOnly = false,
 }: TimeEntryCellProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
 
@@ -40,15 +45,46 @@ export function TimeEntryCell({
     return project?.name || 'Unknown';
   };
 
+  const handleDragStart = (e: DragEvent<HTMLDivElement>, entry: TimeEntry) => {
+    e.dataTransfer.setData(DRAG_MIME_TYPE, entry.id);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    if (readOnly || !onMoveEntry) return;
+    if (!e.dataTransfer.types.includes(DRAG_MIME_TYPE)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (!isDragOver) setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    // Only clear when leaving the cell entirely, not when crossing child elements
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    if (readOnly || !onMoveEntry) return;
+    const entryId = e.dataTransfer.getData(DRAG_MIME_TYPE);
+    setIsDragOver(false);
+    if (!entryId) return;
+    onMoveEntry(entryId, date);
+  };
+
   return (
     <div
       className={cn(
         'border-dark-700 min-h-[100px] border-r p-2 transition-colors last:border-r-0 sm:min-h-[120px]',
         isToday ? 'bg-knowall-green/5' : 'bg-dark-800',
-        isHovered && 'bg-dark-700/50'
+        isHovered && !isDragOver && 'bg-dark-700/50',
+        isDragOver && 'ring-knowall-green/60 bg-knowall-green/10 ring-2 ring-inset'
       )}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     >
       {/* Entries */}
       <div className="space-y-1">
@@ -68,9 +104,12 @@ export function TimeEntryCell({
                     }
                   }
             }
+            draggable={!readOnly && !!onMoveEntry}
+            onDragStart={readOnly ? undefined : (e) => handleDragStart(e, entry)}
             className={cn(
               'w-full rounded-md p-2 text-left transition-colors',
-              !readOnly && 'hover:bg-dark-600/50 cursor-pointer'
+              !readOnly && 'hover:bg-dark-600/50 cursor-pointer',
+              !readOnly && onMoveEntry && 'cursor-grab active:cursor-grabbing'
             )}
             style={{
               backgroundColor: `${getProjectColor(entry.projectId)}20`,

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -8,7 +8,7 @@ import { useTimeEntriesStore, useProjectsStore, useSettingsStore } from '@/hooks
 import { useAuth } from '@/services/auth';
 import { bcClient } from '@/services/bc/bcClient';
 import type { TimeEntry, SelectOption } from '@/types';
-import { formatDateForDisplay } from '@/utils';
+import { formatDate, formatDateForDisplay, getWeekDays } from '@/utils';
 
 // BC Time Sheet Line Description field has a 100-character limit
 const MAX_NOTES_LENGTH = 100;
@@ -18,21 +18,32 @@ interface TimeEntryModalProps {
   onClose: () => void;
   date: string | null;
   entry: TimeEntry | null;
+  weekStart: Date;
 }
 
-export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalProps) {
+export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: TimeEntryModalProps) {
   const { account } = useAuth();
   const userId = account?.localAccountId || '';
 
-  const { addEntry, updateEntry, deleteEntry } = useTimeEntriesStore();
+  const { addEntry, updateEntry, moveEntryDate, deleteEntry } = useTimeEntriesStore();
   const { projects, selectedProject, selectedTask, selectProject, selectTask } = useProjectsStore();
   const { requireTimesheetComments } = useSettingsStore();
 
   const [customerId, setCustomerId] = useState('');
   const [projectId, setProjectId] = useState('');
   const [taskId, setTaskId] = useState('');
+  const [selectedDate, setSelectedDate] = useState('');
   const [hours, setHours] = useState('');
   const [minutes, setMinutes] = useState('');
+
+  const dateOptions: SelectOption[] = useMemo(
+    () =>
+      getWeekDays(weekStart).map((d) => {
+        const value = formatDate(d);
+        return { value, label: formatDateForDisplay(value) };
+      }),
+    [weekStart]
+  );
 
   // When hours is 24, minutes must be 0
   const handleHoursChange = (value: string) => {
@@ -126,6 +137,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
         // Find task by code and use its id
         const task = project?.tasks.find((t) => t.code === entry.taskId);
         setTaskId(task?.id || '');
+        setSelectedDate(entry.date);
         const h = Math.floor(entry.hours);
         const m = Math.round((entry.hours - h) * 60);
         setHours(h.toString());
@@ -137,12 +149,13 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
         setCustomerId(matchedCustomer);
         setProjectId(selectedProject?.id || '');
         setTaskId(selectedTask?.id || '');
+        setSelectedDate(date || '');
         setHours('');
         setMinutes('');
         setNotes('');
       }
     }
-  }, [isOpen, entry, selectedProject, selectedTask, projects, findMatchingCustomerOption]);
+  }, [isOpen, entry, date, selectedProject, selectedTask, projects, findMatchingCustomerOption]);
 
   const projectOptions: SelectOption[] = filteredProjects.map((p) => ({
     value: p.id,
@@ -181,7 +194,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!date || !projectId || !taskId || isSubmitting) return;
+    if (!selectedDate || !projectId || !taskId || isSubmitting) return;
 
     const totalHours = (parseInt(hours) || 0) + (parseInt(minutes) || 0) / 60;
     if (totalHours <= 0) return;
@@ -211,8 +224,15 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
     setIsSubmitting(true);
     try {
       if (entry) {
-        // Update existing entry
-        await updateEntry(entry.id, {
+        // If date changed, move the entry first so subsequent updates target the new detail
+        let targetEntryId = entry.id;
+        if (selectedDate !== entry.date) {
+          await moveEntryDate(entry.id, selectedDate);
+          // Composite ID format is `{lineId}_{date}` — recompute for follow-up update
+          const lineId = entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
+          targetEntryId = `${lineId}_${selectedDate}`;
+        }
+        await updateEntry(targetEntryId, {
           projectId: jobNo,
           taskId: jobTaskNo,
           hours: totalHours,
@@ -225,7 +245,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
           projectId: jobNo,
           taskId: jobTaskNo,
           userId,
-          date,
+          date: selectedDate,
           hours: totalHours,
           notes,
           isBillable: task?.isBillable ?? true,
@@ -262,9 +282,10 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
     }
   };
 
+  const titleDate = selectedDate || date;
   const title = entry
-    ? `Edit time entry for ${date ? formatDateForDisplay(date) : ''}`
-    : `New time entry for ${date ? formatDateForDisplay(date) : ''}`;
+    ? `Edit time entry for ${titleDate ? formatDateForDisplay(titleDate) : ''}`
+    : `New time entry for ${titleDate ? formatDateForDisplay(titleDate) : ''}`;
 
   // Show extension required message if not installed
   if (extensionInstalled === false) {
@@ -299,6 +320,15 @@ export function TimeEntryModal({ isOpen, onClose, date, entry }: TimeEntryModalP
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title}>
       <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Date - constrained to the current week */}
+        <Select
+          label="Date"
+          options={dateOptions}
+          value={selectedDate}
+          onChange={(e) => setSelectedDate(e.target.value)}
+          required
+        />
+
         {/* Customer - only show if multiple customers exist */}
         {showCustomerDropdown && (
           <Select

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -232,13 +232,16 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
           const lineId = entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
           targetEntryId = `${lineId}_${selectedDate}`;
         }
-        await updateEntry(targetEntryId, {
-          projectId: jobNo,
-          taskId: jobTaskNo,
-          hours: totalHours,
-          notes,
-          isBillable: task?.isBillable ?? true,
-        });
+        // Only forward fields the user actually changed. If only the date
+        // changed, skipping updateEntry preserves any same-line merge that
+        // moveEntryDate produced — otherwise the form's hours would clobber
+        // the merged total on the target date.
+        const updates: Partial<TimeEntry> = {};
+        if (totalHours !== entry.hours) updates.hours = totalHours;
+        if (notes !== (entry.notes || '')) updates.notes = notes;
+        if (Object.keys(updates).length > 0) {
+          await updateEntry(targetEntryId, updates);
+        }
       } else {
         // Create new entry
         await addEntry({

--- a/src/components/timesheet/WeeklyTimesheet.tsx
+++ b/src/components/timesheet/WeeklyTimesheet.tsx
@@ -65,6 +65,7 @@ export function WeeklyTimesheet() {
     submitTimesheet,
     reopenTimesheet,
     isTimesheetEditable,
+    moveEntryDate,
   } = useTimeEntriesStore();
 
   const {
@@ -191,6 +192,21 @@ export function WeeklyTimesheet() {
     setIsModalOpen(false);
     setSelectedDate(null);
     setSelectedEntry(null);
+  };
+
+  const handleMoveEntry = async (entryId: string, newDate: string) => {
+    if (!canEdit) {
+      toast.error('Timesheet is not editable. Please reopen it first.');
+      return;
+    }
+    const sourceEntry = entries.find((e) => e.id === entryId);
+    if (sourceEntry && sourceEntry.date === newDate) return;
+    try {
+      await moveEntryDate(entryId, newDate);
+      toast.success('Time entry moved');
+    } catch {
+      toast.error('Failed to move time entry. Please try again.');
+    }
   };
 
   const handleCopyPreviousWeek = async () => {
@@ -610,6 +626,7 @@ Thank you!`)}`}
                     projects={projects}
                     onAddEntry={handleAddEntry}
                     onEditEntry={handleEditEntry}
+                    onMoveEntry={handleMoveEntry}
                     readOnly={!canEdit}
                   />
                 );
@@ -648,6 +665,7 @@ Thank you!`)}`}
           onClose={handleCloseModal}
           date={selectedDate}
           entry={selectedEntry}
+          weekStart={currentWeekStart}
         />
       </div>
     </ExtensionPreviewWrapper>

--- a/src/hooks/useTimeEntriesStore.ts
+++ b/src/hooks/useTimeEntriesStore.ts
@@ -34,6 +34,7 @@ interface TimeEntriesStore {
     >
   ) => Promise<TimeEntry>;
   updateEntry: (entryId: string, updates: Partial<TimeEntry>) => Promise<void>;
+  moveEntryDate: (entryId: string, newDate: string) => Promise<void>;
   deleteEntry: (entryId: string) => Promise<void>;
   clearEntries: () => void;
   copyPreviousWeek: (userId: string) => Promise<void>;
@@ -189,6 +190,24 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
         set({ error: error.message });
       } else {
         const message = error instanceof Error ? error.message : 'Failed to update entry';
+        set({ error: message });
+      }
+      throw error;
+    }
+  },
+
+  moveEntryDate: async (entryId: string, newDate: string) => {
+    const { userEmail } = get();
+    try {
+      await timeEntryService.moveEntryDate(entryId, newDate);
+      // Re-derive entries from the service's cache so merges/splits are reflected
+      const refreshed = timeEntryService.getCachedEntries(userEmail || '');
+      set({ entries: refreshed });
+    } catch (error) {
+      if (error instanceof TimesheetNotEditableError) {
+        set({ error: error.message });
+      } else {
+        const message = error instanceof Error ? error.message : 'Failed to move entry';
         set({ error: message });
       }
       throw error;

--- a/src/services/bc/timeEntryService.ts
+++ b/src/services/bc/timeEntryService.ts
@@ -346,6 +346,87 @@ export const timeEntryService = {
   },
 
   /**
+   * Move an entry to a different date on the same timesheet line.
+   *
+   * BC stores time entries as line+date detail records, so a "date change" is
+   * implemented by writing the hours to the new date and zeroing the old date.
+   * If the same line already has hours on the target date, the hours are summed
+   * (since the line is the same project/task/notes, this is the only sensible merge).
+   */
+  async moveEntryDate(entryId: string, newDate: string): Promise<void> {
+    if (!this._currentTimesheet) {
+      throw new Error('No timesheet loaded. Please refresh the page.');
+    }
+
+    if (!this.isTimesheetEditable()) {
+      const status = bcClient.getTimesheetDisplayStatus(this._currentTimesheet);
+      throw new TimesheetNotEditableError(status);
+    }
+
+    const parsed = parseEntryId(entryId);
+    if (!parsed) {
+      throw new Error('Invalid entry ID format.');
+    }
+
+    const { lineId, date: oldDate } = parsed;
+
+    if (oldDate === newDate) return;
+
+    const line = this._currentTimesheetLines.find((l) => l.id === lineId);
+    if (!line) {
+      throw new Error('Timesheet line not found.');
+    }
+
+    const oldDetail = this._currentTimesheetDetails.find(
+      (d) => d.timeSheetLineNo === line.lineNo && d.date === oldDate
+    );
+    if (!oldDetail || oldDetail.quantity <= 0) {
+      throw new Error('Entry has no hours to move.');
+    }
+
+    const movingHours = oldDetail.quantity;
+    const existingNewDateDetail = this._currentTimesheetDetails.find(
+      (d) => d.timeSheetLineNo === line.lineNo && d.date === newDate
+    );
+    const newTotalHours = movingHours + (existingNewDateDetail?.quantity || 0);
+
+    // Write new date first so the line keeps at least one detail when the old
+    // date is zeroed out — otherwise BC may auto-remove the line.
+    await bcClient.setHoursForDate(lineId, newDate, newTotalHours);
+    await bcClient.setHoursForDate(lineId, oldDate, 0);
+
+    this._currentTimesheetDetails = this._currentTimesheetDetails.filter(
+      (d) => !(d.timeSheetLineNo === line.lineNo && d.date === oldDate)
+    );
+    if (existingNewDateDetail) {
+      existingNewDateDetail.quantity = newTotalHours;
+    } else {
+      this._currentTimesheetDetails.push({
+        id: `temp_${lineId}_${newDate}`,
+        timeSheetNo: this._currentTimesheet.number,
+        timeSheetLineNo: line.lineNo,
+        date: newDate,
+        quantity: newTotalHours,
+      });
+    }
+  },
+
+  /**
+   * Re-derive TimeEntry objects from the cached BC timesheet state without
+   * a network round-trip. Used after mutations that may merge/split entries
+   * (e.g. moveEntryDate) to refresh the store consistently.
+   */
+  getCachedEntries(userId: string): TimeEntry[] {
+    if (!this._currentTimesheet) return [];
+    return bcDataToTimeEntries(
+      this._currentTimesheetLines,
+      this._currentTimesheetDetails,
+      this._currentTimesheet,
+      userId
+    );
+  },
+
+  /**
    * Delete an entry.
    * Sets hours to 0 for the date. If no other hours exist on the line, deletes the line too.
    */


### PR DESCRIPTION
## Summary
- Edit modal gains a Date dropdown constrained to the current week; the title now updates as the date changes. Saving a new date moves the entry.
- Weekly view supports HTML5 drag-and-drop between day columns with a green highlight on the drop target.
- Both gated by the existing `isTimesheetEditable` check, so locked/submitted/approved timesheets stay read-only.
- New service method `moveEntryDate(entryId, newDate)`: writes hours to the new date, then zeros the old one (BC details key on line+date). Same-line conflicts on the target date are merged (hours sum).

<img width="1470" height="871" alt="image" src="https://github.com/user-attachments/assets/2c038cf4-9611-4bd3-9f01-297636d31b82" />



## Test plan
- [x] Open a time entry, change Date to another day in the week, click Update — entry moves; weekly totals update.
- [x] Drag an entry from one day onto another — target column highlights green; on drop entry moves.
- [x] Try dragging an entry onto its own day — no-op, no toast.
- [x] Submit timesheet, then try to drag an entry — drag is gated (modal also blocks edits).
- [x] Move an entry to a day that already has an entry on the *same line* (same project/task/notes) — hours sum.
- [x] Move an entry to a day that has an entry on a *different line* — both entries appear separately on that day.
- [x] Modal title updates as you change the Date dropdown.

Fixes #194
Fixes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)