### PR TITLE
fix: handle BC null-date sentinel on project header dates

### DIFF
--- a/src/components/projects/ProjectHeader.tsx
+++ b/src/components/projects/ProjectHeader.tsx
@@ -23,9 +23,9 @@ import type { BillingMode } from '@/services/bc/projectDetailsService';
  *
  * Treats BC's null-date sentinel ("0001-..." — typically "0001-01-01") as
  * unspecified. The sentinel arrives as a non-empty ISO string, so the
- * empty-check alone misses it and `new Date()` would render it as a year-1
- * garbage date (a timezone shift can also flip it to "31 Dec 1" in negative
- * UTC zones).
+ * empty-check alone misses it; `new Date(...).toLocaleDateString` then
+ * renders it as e.g. "31 Dec 1" — the timezone shift in negative-UTC zones
+ * flips the calendar day, and the year prints unpadded as "1".
  */
 function formatDate(dateStr?: string): string {
   if (!dateStr || dateStr.startsWith('0001-')) return 'Unspecified';

--- a/src/components/projects/ProjectHeader.tsx
+++ b/src/components/projects/ProjectHeader.tsx
@@ -15,22 +15,22 @@ import {
 } from '@heroicons/react/24/outline';
 import { useProjectDetailsStore } from '@/hooks/useProjectDetailsStore';
 import { useCompanyStore } from '@/hooks';
-import { getBCJobUrl } from '@/utils';
-import { cn } from '@/utils';
+import { cn, DATE_FORMAT_FULL, formatDate as formatDateUtil, getBCJobUrl } from '@/utils';
 import type { BillingMode } from '@/services/bc/projectDetailsService';
 
 /**
- * Format a date string for display (e.g., "15 Jan 2025")
+ * Format a date string for display (e.g., "15 Jan 2025").
+ *
+ * Treats BC's null-date sentinel ("0001-..." — typically "0001-01-01") as
+ * unspecified. The sentinel arrives as a non-empty ISO string, so the
+ * empty-check alone misses it and `new Date()` would render it as a year-1
+ * garbage date (a timezone shift can also flip it to "31 Dec 1" in negative
+ * UTC zones).
  */
 function formatDate(dateStr?: string): string {
-  if (!dateStr) return 'Unspecified';
+  if (!dateStr || dateStr.startsWith('0001-')) return 'Unspecified';
   try {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
+    return formatDateUtil(dateStr, DATE_FORMAT_FULL);
   } catch {
     return 'Unspecified';
   }


### PR DESCRIPTION
## Summary
Project details header was showing `Start: 31 Dec 1` / `End: 31 Dec 1` for every project with no start/end set in Business Central.

Cause: BC returns `0001-01-01` as its null-date sentinel. The local `formatDate` in `ProjectHeader.tsx` only guarded against empty strings, so the sentinel reached `new Date(...).toLocaleDateString('en-GB', ...)` and was rendered literally — with a timezone shift in negative-UTC zones flipping it to "31 Dec 1".

- Add a sentinel guard for any `0001-...` date string (returns `Unspecified`).
- Replace the bespoke local helper with the shared `formatDate` util + `DATE_FORMAT_FULL` (`d MMM yyyy`), which uses date-fns `parseISO` and avoids the timezone shift on real dates too.

Codebase already recognises `0001-01-01` as a sentinel in `projectDetailsService.ts:507` for plan-line dates — this brings the project header in line with that convention.

<img width="1021" height="516" alt="image" src="https://github.com/user-attachments/assets/158f046a-f001-4af1-8b91-fc04e0dfe27c" />



## Test plan
- [x] Open a project that has no start/end set in BC (e.g. PR00080) → header shows `Start: Unspecified` / `End: Unspecified`.
- [x] Open a project that has real start/end dates → both render as `d MMM yyyy` (e.g. `31 Dec 2025`).
- [ ] Cross-check on a UTC-negative timezone (the original symptom) — real dates do not shift by a day.

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)