### PR TITLE
fix: convert planning-line quantities to hours on the project list

### DIFF
--- a/src/hooks/usePlanStore.ts
+++ b/src/hooks/usePlanStore.ts
@@ -26,7 +26,11 @@ export interface AllocationBlock {
   hoursPerDay: number;
   totalHours: number;
   color: string;
-  lineType: 'Budget' | 'Billable' | 'Both Budget and Billable';
+  lineType:
+    | 'Budget'
+    | 'Billable'
+    | 'Both Budget and Billable'
+    | 'Both_x0020_Budget_x0020_and_x0020_Billable';
   planningLineNo?: number;
   planningLineId?: string; // BC SystemId (GUID) for PATCH/DELETE operations
 }

--- a/src/services/bc/projectDetailsService.ts
+++ b/src/services/bc/projectDetailsService.ts
@@ -7,7 +7,14 @@ import type {
   BCJobPlanningLine,
   BCTimeEntry,
 } from '@/types';
-import { getWeekStart, buildUOMConversionMap, convertToHours, getHoursPerDay } from '@/utils';
+import {
+  getWeekStart,
+  buildUOMConversionMap,
+  convertToHours,
+  getHoursPerDay,
+  isBudgetPlanningLine,
+  sumPlannedHours,
+} from '@/utils';
 
 // Color palette for projects (same as projectService)
 const PROJECT_COLORS = [
@@ -419,30 +426,18 @@ export const projectDetailsService = {
         }
       }
 
-      // Helper to check if lineType includes Budget (handles URL-encoded spaces from API)
-      const isBudgetLine = (lineType: string) =>
-        lineType === 'Budget' ||
-        lineType === 'Both Budget and Billable' ||
-        lineType === 'Both_x0020_Budget_x0020_and_x0020_Billable';
-
       // Helper to check if lineType includes Billable (handles URL-encoded spaces from API)
       const isBillableLine = (lineType: string) =>
         lineType === 'Billable' ||
         lineType === 'Both Budget and Billable' ||
         lineType === 'Both_x0020_Budget_x0020_and_x0020_Billable';
 
-      // Hours Planned: sum quantity from Resource Budget lines only (hours only apply to resources)
-      // Convert quantity to hours using unit of measure conversion factor
+      // Hours Planned: shared helper — sums Resource Budget lines and converts
+      // each quantity to hours via the per-resource UoM map.
+      hoursPlanned = sumPlannedHours(planningLines, uomConversionMap);
       const resourceLines = planningLines.filter(
         (line: BCJobPlanningLine) => line.type === 'Resource'
       );
-      hoursPlanned = resourceLines
-        .filter((line: BCJobPlanningLine) => isBudgetLine(line.lineType))
-        .reduce(
-          (sum: number, line: BCJobPlanningLine) =>
-            sum + convertToHours(line.number, line.quantity, uomConversionMap),
-          0
-        );
 
       // Extract unit price per resource from planning lines as fallback
       // (only if Resource Card doesn't have unitPrice set)
@@ -458,7 +453,7 @@ export const projectDetailsService = {
 
       // Budget Cost: sum totalCost from ALL Budget lines with breakdown by type
       const budgetLines = planningLines.filter((line: BCJobPlanningLine) =>
-        isBudgetLine(line.lineType)
+        isBudgetPlanningLine(line.lineType)
       );
       budgetCost = budgetLines.reduce(
         (sum: number, line: BCJobPlanningLine) => sum + line.totalCost,
@@ -502,7 +497,7 @@ export const projectDetailsService = {
       // This shows the budgeted hours allocation in the Hours per Week chart
       const plannedHoursMap = new Map<string, number>();
       for (const line of resourceLines) {
-        if (!isBudgetLine(line.lineType)) continue;
+        if (!isBudgetPlanningLine(line.lineType)) continue;
         // Skip lines without a valid planning date (0001-01-01 is BC's default empty date)
         if (!line.planningDate || line.planningDate === '0001-01-01') continue;
 

--- a/src/services/bc/projectService.ts
+++ b/src/services/bc/projectService.ts
@@ -208,6 +208,7 @@ export const projectService = {
    */
   async getProjectBudgets(projectCodes: string[]): Promise<Map<string, number>> {
     const projectBudgets = new Map<string, number>();
+    if (projectCodes.length === 0) return projectBudgets;
 
     // Resource UoM map is per-tenant; fetch once and reuse for every project.
     const resourceUOMs = await bcClient.getResourceUnitsOfMeasure();

--- a/src/services/bc/projectService.ts
+++ b/src/services/bc/projectService.ts
@@ -1,13 +1,6 @@
 import { bcClient } from './bcClient';
-import type {
-  Project,
-  Task,
-  BCProject,
-  BCJobTask,
-  BCTimeSheet,
-  BCTimeSheetLine,
-  BCJobPlanningLine,
-} from '@/types';
+import type { Project, Task, BCProject, BCJobTask, BCTimeSheet, BCTimeSheetLine } from '@/types';
+import { buildUOMConversionMap, sumPlannedHours } from '@/utils';
 
 // Color palette for projects
 const PROJECT_COLORS = [
@@ -205,20 +198,25 @@ export const projectService = {
   /**
    * Fetch budget hours for all projects from Job Planning Lines.
    * Returns a map of project code -> budget hours.
+   *
+   * Uses the same rule as the project details page: only Resource Budget
+   * lines count, and each line's quantity is converted to hours via the
+   * UoM map (so DAY-based resources are scaled by their hours-per-day
+   * factor). Without the conversion the list would show raw days against
+   * a column labelled "h", and the Remaining figure would go strongly
+   * negative (issue #192).
    */
   async getProjectBudgets(projectCodes: string[]): Promise<Map<string, number>> {
     const projectBudgets = new Map<string, number>();
 
-    // Fetch budget for each project in parallel
+    // Resource UoM map is per-tenant; fetch once and reuse for every project.
+    const resourceUOMs = await bcClient.getResourceUnitsOfMeasure();
+    const uomConversionMap = buildUOMConversionMap(resourceUOMs);
+
     const budgetPromises = projectCodes.map(async (projectCode) => {
       try {
         const planningLines = await bcClient.getJobPlanningLines(projectCode);
-
-        // Sum quantity for Resource type lines (hours-based budgets)
-        const budgetHours = planningLines
-          .filter((line: BCJobPlanningLine) => line.type === 'Resource')
-          .reduce((sum: number, line: BCJobPlanningLine) => sum + line.quantity, 0);
-
+        const budgetHours = sumPlannedHours(planningLines, uomConversionMap);
         if (budgetHours > 0) {
           projectBudgets.set(projectCode, budgetHours);
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,7 +102,15 @@ export interface BCJobPlanningLine {
   jobTaskNo: string;
   lineNo: number;
   planningDate: string;
-  lineType: 'Budget' | 'Billable' | 'Both Budget and Billable';
+  // BC's OData JSON serializer URL-encodes spaces in named enum values, so
+  // "Both Budget and Billable" can also arrive as the `_x0020_` form. Both
+  // shapes are valid at runtime; helpers like `isBudgetPlanningLine` accept
+  // either. Keep the union honest so narrowing comparisons can't miss it.
+  lineType:
+    | 'Budget'
+    | 'Billable'
+    | 'Both Budget and Billable'
+    | 'Both_x0020_Budget_x0020_and_x0020_Billable';
   type: 'Resource' | 'Item' | 'G/L Account';
   number: string; // The "No." field - resource/item/GL account number
   description: string;

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -1,4 +1,4 @@
-import type { BCResourceUnitOfMeasure } from '@/types';
+import type { BCJobPlanningLine, BCResourceUnitOfMeasure } from '@/types';
 
 /**
  * UOM conversion map: "resourceNo:code" → qtyPerUnitOfMeasure
@@ -122,4 +122,36 @@ export function isResourceDayBased(
  */
 export function formatHours(hours: number): string {
   return parseFloat(hours.toFixed(2)).toString();
+}
+
+/**
+ * Whether a planning line's `lineType` counts as a Budget line.
+ *
+ * BC's OData layer URL-encodes spaces in named enum values, so
+ * "Both Budget and Billable" arrives over the wire as
+ * "Both_x0020_Budget_x0020_and_x0020_Billable" — handle both forms.
+ */
+export function isBudgetPlanningLine(lineType: string | undefined): boolean {
+  return (
+    lineType === 'Budget' ||
+    lineType === 'Both Budget and Billable' ||
+    lineType === 'Both_x0020_Budget_x0020_and_x0020_Billable'
+  );
+}
+
+/**
+ * Sum the planned hours from a project's planning lines.
+ *
+ * Mirrors the rule used on the project details page: only Resource lines
+ * tagged as Budget (or Both Budget and Billable) count, and each line's
+ * quantity is converted to hours via the UoM map (so DAY-based resources
+ * are scaled by the per-resource hours-per-day factor).
+ */
+export function sumPlannedHours(
+  planningLines: BCJobPlanningLine[],
+  uomConversionMap: UOMConversionMap
+): number {
+  return planningLines
+    .filter((line) => line.type === 'Resource' && isBudgetPlanningLine(line.lineType))
+    .reduce((sum, line) => sum + convertToHours(line.number, line.quantity, uomConversionMap), 0);
 }

--- a/tests/unit/utils/unitConversion.test.ts
+++ b/tests/unit/utils/unitConversion.test.ts
@@ -5,8 +5,31 @@ import {
   convertToHours,
   convertFromHours,
   isResourceDayBased,
+  isBudgetPlanningLine,
+  sumPlannedHours,
 } from '@/utils/unitConversion';
-import type { BCResourceUnitOfMeasure } from '@/types';
+import type { BCJobPlanningLine, BCResourceUnitOfMeasure } from '@/types';
+
+// Helper to create planning-line records with the fields the helpers care about.
+function makeLine(partial: Partial<BCJobPlanningLine>): BCJobPlanningLine {
+  return {
+    id: 'planning-line',
+    jobNo: 'PR00010',
+    jobTaskNo: '1000',
+    lineNo: 1000,
+    planningDate: '2026-01-01',
+    lineType: 'Budget',
+    type: 'Resource',
+    number: 'R001',
+    description: '',
+    quantity: 0,
+    unitCost: 0,
+    unitPrice: 0,
+    totalCost: 0,
+    totalPrice: 0,
+    ...partial,
+  } as BCJobPlanningLine;
+}
 
 // Helper to create UOM records with required fields
 function makeUOM(
@@ -151,6 +174,85 @@ describe('unitConversion', () => {
     it('returns false for zero factor', () => {
       const map = new Map([['R001:HOUR', 0]]);
       expect(isResourceDayBased('R001', map)).toBe(false);
+    });
+  });
+
+  describe('isBudgetPlanningLine', () => {
+    it('accepts the plain "Budget" lineType', () => {
+      expect(isBudgetPlanningLine('Budget')).toBe(true);
+    });
+
+    it('accepts the plain "Both Budget and Billable" lineType', () => {
+      expect(isBudgetPlanningLine('Both Budget and Billable')).toBe(true);
+    });
+
+    it('accepts the URL-encoded "Both_x0020_Budget_x0020_and_x0020_Billable" lineType', () => {
+      expect(isBudgetPlanningLine('Both_x0020_Budget_x0020_and_x0020_Billable')).toBe(true);
+    });
+
+    it('rejects the "Billable" lineType', () => {
+      expect(isBudgetPlanningLine('Billable')).toBe(false);
+    });
+
+    it('rejects undefined and unknown values', () => {
+      expect(isBudgetPlanningLine(undefined)).toBe(false);
+      expect(isBudgetPlanningLine('Something Else')).toBe(false);
+      expect(isBudgetPlanningLine('')).toBe(false);
+    });
+  });
+
+  describe('sumPlannedHours', () => {
+    it('sums Resource Budget lines, converting DAY quantities to hours', () => {
+      const map = buildUOMConversionMap([makeUOM('R001', 'HOUR', 7.5)]);
+      const lines = [
+        makeLine({ type: 'Resource', lineType: 'Budget', number: 'R001', quantity: 4 }),
+        makeLine({ type: 'Resource', lineType: 'Budget', number: 'R001', quantity: 2 }),
+      ];
+      // 4d × 7.5 + 2d × 7.5 = 30 + 15 = 45h
+      expect(sumPlannedHours(lines, map)).toBeCloseTo(45);
+    });
+
+    it('counts "Both Budget and Billable" lines (plain and encoded forms)', () => {
+      const map = buildUOMConversionMap([makeUOM('R001', 'HOUR', 1)]);
+      const lines = [
+        makeLine({ type: 'Resource', lineType: 'Both Budget and Billable', quantity: 3 }),
+        makeLine({
+          type: 'Resource',
+          lineType: 'Both_x0020_Budget_x0020_and_x0020_Billable',
+          quantity: 5,
+        }),
+      ];
+      expect(sumPlannedHours(lines, map)).toBe(8);
+    });
+
+    it('excludes Billable-only lines', () => {
+      const map = buildUOMConversionMap([makeUOM('R001', 'HOUR', 1)]);
+      const lines = [
+        makeLine({ type: 'Resource', lineType: 'Budget', quantity: 4 }),
+        makeLine({ type: 'Resource', lineType: 'Billable', quantity: 100 }),
+      ];
+      expect(sumPlannedHours(lines, map)).toBe(4);
+    });
+
+    it('excludes non-Resource lines (Item, G/L Account)', () => {
+      const map = buildUOMConversionMap([makeUOM('R001', 'HOUR', 1)]);
+      const lines = [
+        makeLine({ type: 'Resource', lineType: 'Budget', quantity: 4 }),
+        makeLine({ type: 'Item', lineType: 'Budget', quantity: 100 }),
+        makeLine({ type: 'G/L Account', lineType: 'Budget', quantity: 100 }),
+      ];
+      expect(sumPlannedHours(lines, map)).toBe(4);
+    });
+
+    it('returns 0 for an empty list', () => {
+      const map = buildUOMConversionMap([]);
+      expect(sumPlannedHours([], map)).toBe(0);
+    });
+
+    it('uses raw quantity when the resource has no UoM conversion', () => {
+      const map = buildUOMConversionMap([]);
+      const lines = [makeLine({ type: 'Resource', lineType: 'Budget', quantity: 6.5 })];
+      expect(sumPlannedHours(lines, map)).toBe(6.5);
     });
   });
 });


### PR DESCRIPTION
## Summary
The project list's **Planned** column was summing `BCJobPlanningLine.quantity` directly with no UoM conversion. Projects whose resources are configured in **DAYs** therefore showed raw days against a column labelled "h" — for Cairn Homes – Support & Maintenance, 31.5d was rendered as **61h** (planned), which then made **Remaining** go strongly negative (`-107h (276%)`). The project details page already converts via the per-resource UoM map, so the list and details views disagreed for the same project.
<img width="1303" height="886" alt="image" src="https://github.com/user-attachments/assets/5d8b1f2f-a1e8-444e-9d64-c21a7dfdf277" />


- Added `sumPlannedHours(planningLines, uomMap)` and `isBudgetPlanningLine` helpers in `utils/unitConversion.ts`. Same rule as the details page: only Resource Budget lines (or *Both Budget and Billable*, including the `_x0020_`-encoded variant), with each quantity converted to hours via the UoM map.
- `projectService.getProjectBudgets` now fetches the resource UoM table once per call and uses `sumPlannedHours`, so the list matches the details page.
- `projectDetailsService` delegates to the same shared helper instead of carrying its own copy, so the two stay in sync going forward.

## Test plan
- [x] On the projects list, Cairn Homes – Support & Maintenance (PR00010) shows **Planned 237h** and **Remaining ~+68.5h** (was 61h / -107h / 276%).
- [x] Open the project details page for the same project — the values match.
- [x] Spot-check another DAY-based project (e.g. W&R Barnett rows in #192's screenshot): Planned column now reads in hours, Remaining is no longer wildly negative.
- [x] HOUR-based projects: Planned column unchanged.
- [x] Sort by Planned and Remaining — order is consistent with the new values.

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)