### PR TITLE
fix: show totals in chart legend and days in Time Spent budgeted sub-text

### DIFF
--- a/src/components/projects/ProjectCharts.tsx
+++ b/src/components/projects/ProjectCharts.tsx
@@ -328,6 +328,19 @@ function WeeklyBarChart({ data, offsetWeeks }: WeeklyBarChartProps) {
     [data, offsetWeeks]
   );
 
+  const legendTotals = useMemo(
+    () =>
+      displayData.reduce(
+        (acc, d) => ({
+          planned: acc.planned + d.plannedHours,
+          approved: acc.approved + d.approvedHours,
+          pending: acc.pending + d.pendingHours,
+        }),
+        { planned: 0, approved: 0, pending: 0 }
+      ),
+    [displayData]
+  );
+
   const maxHours = useMemo(() => {
     // Consider both actual hours and planned hours for the max
     const max = Math.max(...displayData.map((d) => Math.max(d.hours, d.plannedHours)), 0);
@@ -485,19 +498,19 @@ function WeeklyBarChart({ data, offsetWeeks }: WeeklyBarChartProps) {
         ))}
       </div>
 
-      {/* Legend */}
+      {/* Legend — totals are summed across the visible weeks */}
       <div className="mt-3 flex items-center justify-center gap-6 text-xs text-gray-400">
         <div className="flex items-center gap-1.5">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-gray-600" />
-          <span>Planned</span>
+          <span>Planned ({legendTotals.planned.toFixed(1)}h)</span>
         </div>
         <div className="flex items-center gap-1.5">
           <span className="bg-thyme-500 inline-block h-2.5 w-2.5 rounded-sm" />
-          <span>Approved</span>
+          <span>Approved ({legendTotals.approved.toFixed(1)}h)</span>
         </div>
         <div className="flex items-center gap-1.5">
           <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-500" />
-          <span>Pending</span>
+          <span>Pending ({legendTotals.pending.toFixed(1)}h)</span>
         </div>
       </div>
     </div>

--- a/src/components/projects/ProjectKPICards.tsx
+++ b/src/components/projects/ProjectKPICards.tsx
@@ -153,7 +153,7 @@ export function ProjectKPICards() {
       label: 'Time Spent',
       value: formatHoursWithDays(hoursSpent, hoursPerDay),
       subLabel: hasPlannedHours
-        ? `${percentUsed}% of ${hoursPlanned.toFixed(0)}h budgeted`
+        ? `${percentUsed}% of ${formatHoursWithDays(hoursPlanned, hoursPerDay)} budgeted`
         : 'From timesheets',
       icon: ClockIcon,
       color: 'text-thyme-400',


### PR DESCRIPTION
## Summary
Two small project-details-page fixes on the same screen:

- **Hours per Week chart legend** — shows the sum of Planned, Approved and Pending hours across the visible weeks (e.g. `Planned (237.0h)   Approved (158.5h)   Pending (10.0h)`). Totals re-compute when navigating weeks via the arrows / "This Week" button. Implemented via a `legendTotals` `useMemo` derived from the same `displayData` that drives the bars.
- **Time Spent card** — the "X% of Yh budgeted" sub-text now uses the shared `formatHoursWithDays` helper, so it shows `71% of 237.0h (31.5d) budgeted` instead of `71% of 237h budgeted`. Matches the format already used on the neighbouring Time Budgeted card.

<img width="1309" height="904" alt="image" src="https://github.com/user-attachments/assets/d09d9712-d17c-4143-b061-1fae2eb540fa" />

## Test plan
- [x] Open project details for PR00010 — Cairn Homes – Support & Maintenance.
- [x] Hours per Week legend reads `Planned (Xh)   Approved (Yh)   Pending (Zh)` and the figures sum to the visible bars.
- [x] Click the previous-week / next-week arrows or "This Week" — the legend totals update to match the new visible window.
- [x] Time Spent card sub-text reads `X% of <budget>h (<budgetdays>d) budgeted`, matching the format on the Time Budgeted card next to it.
- [x] No regression on the Spend vs Budget chart (separate legend, untouched).

Fixes #202
Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)