### PR TITLE
fix: persist project/task changes when editing a time entry

### DIFF
--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -265,8 +265,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
           if (selectedDate !== entry.date) {
             await moveEntryDate(entry.id, selectedDate);
             // Composite ID format is `{lineId}_{date}` — recompute for follow-up update
-            const lineId =
-              entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
+            const lineId = entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
             targetEntryId = `${lineId}_${selectedDate}`;
           }
           // Only forward fields the user actually changed. If only the date

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { TrashIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { Modal, Button, Input, Select } from '@/components/ui';
@@ -138,44 +138,51 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
     [customerOptions]
   );
 
-  // Reset form when modal opens or a different entry is loaded.
-  // Intentionally omits selectedProject/selectedTask/projects/findMatchingCustomerOption
-  // from deps: handleProjectChange/handleTaskChange call selectProject/selectTask,
-  // which would otherwise re-run this effect and clobber the user's new selection
-  // with the original entry values (#208).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Reset form only when the modal opens or the entry/date being edited
+  // changes. The effect still depends on projects/findMatchingCustomerOption
+  // so a background refresh produces consistent state, but a resetKey guard
+  // skips the body on incidental dep changes (e.g. handleProjectChange firing
+  // selectProject mid-edit) so the user's in-progress selection is not
+  // clobbered with the original entry values (#208).
+  const lastResetKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    if (isOpen) {
-      if (entry) {
-        // Editing existing entry - entry.projectId is a job code (e.g., "PR00030"), not a GUID
-        const project = projects.find((p) => p.code === entry.projectId);
-        // Use matching customer option value to ensure Select works correctly
-        const matchedCustomer = findMatchingCustomerOption(project?.customerName);
-        setCustomerId(matchedCustomer);
-        // Use project.id (GUID) for form state since dropdown options use GUIDs
-        setProjectId(project?.id || '');
-        // Find task by code and use its id
-        const task = project?.tasks.find((t) => t.code === entry.taskId);
-        setTaskId(task?.id || '');
-        setSelectedDate(entry.date);
-        const h = Math.floor(entry.hours);
-        const m = Math.round((entry.hours - h) * 60);
-        setHours(h.toString());
-        setMinutes(m.toString());
-        setNotes(entry.notes || '');
-      } else {
-        // New entry - use matching customer option value
-        const matchedCustomer = findMatchingCustomerOption(selectedProject?.customerName);
-        setCustomerId(matchedCustomer);
-        setProjectId(selectedProject?.id || '');
-        setTaskId(selectedTask?.id || '');
-        setSelectedDate(date || '');
-        setHours('');
-        setMinutes('');
-        setNotes('');
-      }
+    const resetKey = isOpen ? `${entry?.id ?? 'new'}|${date ?? ''}` : null;
+    if (!isOpen) {
+      lastResetKeyRef.current = null;
+      return;
     }
-  }, [isOpen, entry, date]);
+    if (lastResetKeyRef.current === resetKey) return;
+    lastResetKeyRef.current = resetKey;
+
+    if (entry) {
+      // Editing existing entry - entry.projectId is a job code (e.g., "PR00030"), not a GUID
+      const project = projects.find((p) => p.code === entry.projectId);
+      // Use matching customer option value to ensure Select works correctly
+      const matchedCustomer = findMatchingCustomerOption(project?.customerName);
+      setCustomerId(matchedCustomer);
+      // Use project.id (GUID) for form state since dropdown options use GUIDs
+      setProjectId(project?.id || '');
+      // Find task by code and use its id
+      const task = project?.tasks.find((t) => t.code === entry.taskId);
+      setTaskId(task?.id || '');
+      setSelectedDate(entry.date);
+      const h = Math.floor(entry.hours);
+      const m = Math.round((entry.hours - h) * 60);
+      setHours(h.toString());
+      setMinutes(m.toString());
+      setNotes(entry.notes || '');
+    } else {
+      // New entry - use matching customer option value
+      const matchedCustomer = findMatchingCustomerOption(selectedProject?.customerName);
+      setCustomerId(matchedCustomer);
+      setProjectId(selectedProject?.id || '');
+      setTaskId(selectedTask?.id || '');
+      setSelectedDate(date || '');
+      setHours('');
+      setMinutes('');
+      setNotes('');
+    }
+  }, [isOpen, entry, date, projects, findMatchingCustomerOption, selectedProject, selectedTask]);
 
   const projectOptions: SelectOption[] = filteredProjects.map((p) => ({
     value: p.id,
@@ -246,9 +253,10 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
       if (entry) {
         // A BC timesheet line is bound to a single project+task, so a project
         // or task change can't be patched in place — replace the entry by
-        // deleting the original and creating a new one on the chosen date.
+        // creating the new one first and then deleting the original. Doing
+        // the create before the delete means a BC failure mid-flight leaves
+        // the original hours intact instead of silently losing them.
         if (jobNo !== entry.projectId || jobTaskNo !== entry.taskId) {
-          await deleteEntry(entry.id);
           await addEntry({
             projectId: jobNo,
             taskId: jobTaskNo,
@@ -259,6 +267,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
             isBillable: task?.isBillable ?? true,
             isRunning: false,
           });
+          await deleteEntry(entry.id);
         } else {
           // If date changed, move the entry first so subsequent updates target the new detail
           let targetEntryId = entry.id;

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -138,7 +138,12 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
     [customerOptions]
   );
 
-  // Reset form when modal opens
+  // Reset form when modal opens or a different entry is loaded.
+  // Intentionally omits selectedProject/selectedTask/projects/findMatchingCustomerOption
+  // from deps: handleProjectChange/handleTaskChange call selectProject/selectTask,
+  // which would otherwise re-run this effect and clobber the user's new selection
+  // with the original entry values (#208).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isOpen) {
       if (entry) {
@@ -170,7 +175,7 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
         setNotes('');
       }
     }
-  }, [isOpen, entry, date, selectedProject, selectedTask, projects, findMatchingCustomerOption]);
+  }, [isOpen, entry, date]);
 
   const projectOptions: SelectOption[] = filteredProjects.map((p) => ({
     value: p.id,
@@ -239,23 +244,41 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
     setIsSubmitting(true);
     try {
       if (entry) {
-        // If date changed, move the entry first so subsequent updates target the new detail
-        let targetEntryId = entry.id;
-        if (selectedDate !== entry.date) {
-          await moveEntryDate(entry.id, selectedDate);
-          // Composite ID format is `{lineId}_{date}` — recompute for follow-up update
-          const lineId = entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
-          targetEntryId = `${lineId}_${selectedDate}`;
-        }
-        // Only forward fields the user actually changed. If only the date
-        // changed, skipping updateEntry preserves any same-line merge that
-        // moveEntryDate produced — otherwise the form's hours would clobber
-        // the merged total on the target date.
-        const updates: Partial<TimeEntry> = {};
-        if (totalHours !== entry.hours) updates.hours = totalHours;
-        if (notes !== (entry.notes || '')) updates.notes = notes;
-        if (Object.keys(updates).length > 0) {
-          await updateEntry(targetEntryId, updates);
+        // A BC timesheet line is bound to a single project+task, so a project
+        // or task change can't be patched in place — replace the entry by
+        // deleting the original and creating a new one on the chosen date.
+        if (jobNo !== entry.projectId || jobTaskNo !== entry.taskId) {
+          await deleteEntry(entry.id);
+          await addEntry({
+            projectId: jobNo,
+            taskId: jobTaskNo,
+            userId,
+            date: selectedDate,
+            hours: totalHours,
+            notes,
+            isBillable: task?.isBillable ?? true,
+            isRunning: false,
+          });
+        } else {
+          // If date changed, move the entry first so subsequent updates target the new detail
+          let targetEntryId = entry.id;
+          if (selectedDate !== entry.date) {
+            await moveEntryDate(entry.id, selectedDate);
+            // Composite ID format is `{lineId}_{date}` — recompute for follow-up update
+            const lineId =
+              entry.bcTimeSheetLineId || entry.id.replace(/_\d{4}-\d{2}-\d{2}$/, '');
+            targetEntryId = `${lineId}_${selectedDate}`;
+          }
+          // Only forward fields the user actually changed. If only the date
+          // changed, skipping updateEntry preserves any same-line merge that
+          // moveEntryDate produced — otherwise the form's hours would clobber
+          // the merged total on the target date.
+          const updates: Partial<TimeEntry> = {};
+          if (totalHours !== entry.hours) updates.hours = totalHours;
+          if (notes !== (entry.notes || '')) updates.notes = notes;
+          if (Object.keys(updates).length > 0) {
+            await updateEntry(targetEntryId, updates);
+          }
         }
       } else {
         // Create new entry

--- a/src/components/timesheet/TimeEntryModal.tsx
+++ b/src/components/timesheet/TimeEntryModal.tsx
@@ -139,11 +139,11 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
   );
 
   // Reset form only when the modal opens or the entry/date being edited
-  // changes. The effect still depends on projects/findMatchingCustomerOption
-  // so a background refresh produces consistent state, but a resetKey guard
-  // skips the body on incidental dep changes (e.g. handleProjectChange firing
-  // selectProject mid-edit) so the user's in-progress selection is not
-  // clobbered with the original entry values (#208).
+  // changes. A resetKey ref gates the body to the open-transition and entry
+  // identity, so unrelated dep changes — selectProject/selectTask firing
+  // mid-edit, or a background projects refresh — don't clobber the user's
+  // in-progress selection with the original entry values (#208). Deps are
+  // still listed honestly for exhaustive-deps; the guard makes them no-ops.
   const lastResetKeyRef = useRef<string | null>(null);
   useEffect(() => {
     const resetKey = isOpen ? `${entry?.id ?? 'new'}|${date ?? ''}` : null;
@@ -267,7 +267,18 @@ export function TimeEntryModal({ isOpen, onClose, date, entry, weekStart }: Time
             isBillable: task?.isBillable ?? true,
             isRunning: false,
           });
-          await deleteEntry(entry.id);
+          // The add succeeded; if the delete fails the user briefly has both
+          // the old and new entries. Surface a specific message so they know
+          // exactly what to clean up rather than a generic save failure.
+          try {
+            await deleteEntry(entry.id);
+          } catch {
+            toast.error(
+              'New entry saved, but the original could not be removed. Please delete it manually.'
+            );
+            onClose();
+            return;
+          }
         } else {
           // If date changed, move the entry first so subsequent updates target the new detail
           let targetEntryId = entry.id;


### PR DESCRIPTION
## Summary

- The edit modal's reset effect listed `selectedProject`/`selectedTask` (and friends) in deps, so picking a new project mid-edit fired `selectProject` → re-ran the effect → snapped the form back to the original entry values.
- `handleSubmit` only forwarded `hours`/`notes` on update — project and task changes were silently dropped even when the UI did show them.
- A BC timesheet line is bound to a single project+task, so a project/task change is now treated as a replacement: delete the original entry and create a new line on the chosen date. Hours-only / notes-only / date-only edits still use the existing in-place path.

Fixes #208

## Test plan

- [x] Edit an existing entry, change the project and/or task, save → new project/task is reflected on the timesheet and persisted in BC
- [x] Edit an existing entry, change only hours/notes, save → existing line is updated in place (no new line created)
- [x] Edit an existing entry, change only the date, save → entry moves to the new date on the same line
- [x] Create a new entry → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)