### PR TITLE
fix: decode BC OData enum encoding so G/L Account lines show in cost breakdowns

### DIFF
--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -41,6 +41,22 @@ const THYME_API_VERSION = 'v1.0';
 // Valid TimeSheetStatus values for whitelist validation
 const VALID_TIMESHEET_STATUSES = ['Open', 'Submitted', 'Rejected', 'Approved', 'Posted'] as const;
 
+// Known planning-line enum values, used to narrow decoded BC strings back to
+// the typed unions. An unrecognized decode falls back to the original value
+// rather than being blindly cast, so unexpected BC enums aren't masked.
+const PLANNING_LINE_TYPES = ['Resource', 'Item', 'G/L Account'] as const;
+const PLANNING_LINE_LINE_TYPES = [
+  'Budget',
+  'Billable',
+  'Both Budget and Billable',
+] as const;
+
+// Narrow a decoded enum string to one of the allowed values, falling back to
+// the original (still-typed) value when the decode isn't a recognized member.
+function narrowEnum<T extends string>(decoded: string, allowed: readonly T[], fallback: T): T {
+  return (allowed as readonly string[]).includes(decoded) ? (decoded as T) : fallback;
+}
+
 // Available environments to query
 const BC_ENVIRONMENTS: BCEnvironmentType[] = ['sandbox', 'production'];
 
@@ -473,8 +489,8 @@ class BusinessCentralClient {
   private normalizePlanningLines(lines: BCJobPlanningLine[]): BCJobPlanningLine[] {
     return lines.map((line) => ({
       ...line,
-      type: decodeBCEnum(line.type) as BCJobPlanningLine['type'],
-      lineType: decodeBCEnum(line.lineType) as BCJobPlanningLine['lineType'],
+      type: narrowEnum(decodeBCEnum(line.type), PLANNING_LINE_TYPES, line.type),
+      lineType: narrowEnum(decodeBCEnum(line.lineType), PLANNING_LINE_LINE_TYPES, line.lineType),
     }));
   }
 

--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -20,7 +20,7 @@ import type {
   TimesheetDisplayStatus,
   PaginatedResponse,
 } from '@/types';
-import { getTimesheetDisplayStatus } from '@/utils';
+import { getTimesheetDisplayStatus, decodeBCEnum } from '@/utils';
 
 const BC_BASE_URL =
   process.env.NEXT_PUBLIC_BC_BASE_URL || 'https://api.businesscentral.dynamics.com/v2.0';
@@ -466,6 +466,18 @@ class BusinessCentralClient {
     return this.fetch<BCJobTask>(`/jobTasks(${jobTaskId})`);
   }
 
+  // Decode BC's OData enum encoding on planning-line fields so downstream code
+  // can compare against the plain values. BC serializes named enums like
+  // `type` "G/L Account" as "G_x002F_L_x0020_Account" and `lineType`
+  // "Both Budget and Billable" as "Both_x0020_Budget_x0020_and_x0020_Billable".
+  private normalizePlanningLines(lines: BCJobPlanningLine[]): BCJobPlanningLine[] {
+    return lines.map((line) => ({
+      ...line,
+      type: decodeBCEnum(line.type) as BCJobPlanningLine['type'],
+      lineType: decodeBCEnum(line.lineType) as BCJobPlanningLine['lineType'],
+    }));
+  }
+
   // Job Planning Lines - requires Thyme BC Extension v1.6.0+
   // Provides budget/planned hours data for projects
   async getJobPlanningLines(jobNumber: string): Promise<BCJobPlanningLine[]> {
@@ -502,7 +514,7 @@ class BusinessCentralClient {
       }
 
       const data = await response.json();
-      return data.value || [];
+      return this.normalizePlanningLines(data.value || []);
     } catch (error) {
       console.error('[BC API] Error fetching job planning lines:', error);
       return [];
@@ -592,7 +604,7 @@ class BusinessCentralClient {
       }
 
       const data = await response.json();
-      return data.value || [];
+      return this.normalizePlanningLines(data.value || []);
     } catch (error) {
       console.error('[BC API] Error fetching job planning lines for week:', error);
       return [];

--- a/src/services/bc/bcClient.ts
+++ b/src/services/bc/bcClient.ts
@@ -45,11 +45,7 @@ const VALID_TIMESHEET_STATUSES = ['Open', 'Submitted', 'Rejected', 'Approved', '
 // the typed unions. An unrecognized decode falls back to the original value
 // rather than being blindly cast, so unexpected BC enums aren't masked.
 const PLANNING_LINE_TYPES = ['Resource', 'Item', 'G/L Account'] as const;
-const PLANNING_LINE_LINE_TYPES = [
-  'Budget',
-  'Billable',
-  'Both Budget and Billable',
-] as const;
+const PLANNING_LINE_LINE_TYPES = ['Budget', 'Billable', 'Both Budget and Billable'] as const;
 
 // Narrow a decoded enum string to one of the allowed values, falling back to
 // the original (still-typed) value when the decode isn't a recognized member.

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -133,14 +133,34 @@ export function formatHours(hours: number): string {
  * (`/` → `_x002F_`, space → `_x0020_`), and the lineType "Both Budget and
  * Billable" arrives as "Both_x0020_Budget_x0020_and_x0020_Billable".
  *
+ * A literal underscore that would otherwise start an escape is itself encoded
+ * as `_x005F_`, so a source value that genuinely contains `_x0020_` arrives as
+ * `_x005F_x0020_`. We scan left-to-right and consume each `_xHHHH_` as a single
+ * unit, so the `_x005F_` decodes to a literal `_` and the following `x0020_` is
+ * left untouched (rather than being re-read as a space).
+ *
  * Decoding once at the data boundary lets all downstream comparisons use the
  * plain, human-readable values (e.g. `type === 'G/L Account'`).
  */
 export function decodeBCEnum(value: string | undefined): string {
   if (!value) return '';
-  return value.replace(/_x([0-9A-Fa-f]{4})_/g, (_match, hex) =>
-    String.fromCharCode(parseInt(hex, 16))
-  );
+  // Sticky regex anchors each match at the current scan position, so we never
+  // re-scan already-decoded output or share a delimiter `_` between escapes.
+  const escape = /_x([0-9A-Fa-f]{4})_/y;
+  let result = '';
+  let i = 0;
+  while (i < value.length) {
+    escape.lastIndex = i;
+    const match = escape.exec(value);
+    if (match) {
+      result += String.fromCharCode(parseInt(match[1], 16));
+      i += match[0].length;
+    } else {
+      result += value[i];
+      i += 1;
+    }
+  }
+  return result;
 }
 
 /**

--- a/src/utils/unitConversion.ts
+++ b/src/utils/unitConversion.ts
@@ -125,6 +125,25 @@ export function formatHours(hours: number): string {
 }
 
 /**
+ * Decode BC's OData enum-value encoding.
+ *
+ * BC's OData JSON serializer URL-encodes any character that isn't valid in an
+ * identifier as `_xHHHH_`, where HHHH is the UTF-16 code unit in hex. So the
+ * planning-line type "G/L Account" arrives as "G_x002F_L_x0020_Account"
+ * (`/` → `_x002F_`, space → `_x0020_`), and the lineType "Both Budget and
+ * Billable" arrives as "Both_x0020_Budget_x0020_and_x0020_Billable".
+ *
+ * Decoding once at the data boundary lets all downstream comparisons use the
+ * plain, human-readable values (e.g. `type === 'G/L Account'`).
+ */
+export function decodeBCEnum(value: string | undefined): string {
+  if (!value) return '';
+  return value.replace(/_x([0-9A-Fa-f]{4})_/g, (_match, hex) =>
+    String.fromCharCode(parseInt(hex, 16))
+  );
+}
+
+/**
  * Whether a planning line's `lineType` counts as a Budget line.
  *
  * BC's OData layer URL-encodes spaces in named enum values, so

--- a/tests/unit/utils/unitConversion.test.ts
+++ b/tests/unit/utils/unitConversion.test.ts
@@ -220,6 +220,17 @@ describe('unitConversion', () => {
       expect(decodeBCEnum('G/L Account')).toBe('G/L Account');
     });
 
+    it('treats _x005F_ as a literal underscore and leaves the following escape intact', () => {
+      // A source value that genuinely contains "_x0020_" is encoded as
+      // "_x005F_x0020_"; it must decode back to the literal "_x0020_", not " ".
+      expect(decodeBCEnum('_x005F_x0020_')).toBe('_x0020_');
+    });
+
+    it('decodes adjacent escapes independently', () => {
+      // "//" → each "/" encoded separately as "_x002F_".
+      expect(decodeBCEnum('_x002F__x002F_')).toBe('//');
+    });
+
     it('returns an empty string for undefined or empty input', () => {
       expect(decodeBCEnum(undefined)).toBe('');
       expect(decodeBCEnum('')).toBe('');

--- a/tests/unit/utils/unitConversion.test.ts
+++ b/tests/unit/utils/unitConversion.test.ts
@@ -7,6 +7,7 @@ import {
   isResourceDayBased,
   isBudgetPlanningLine,
   sumPlannedHours,
+  decodeBCEnum,
 } from '@/utils/unitConversion';
 import type { BCJobPlanningLine, BCResourceUnitOfMeasure } from '@/types';
 
@@ -198,6 +199,30 @@ describe('unitConversion', () => {
       expect(isBudgetPlanningLine(undefined)).toBe(false);
       expect(isBudgetPlanningLine('Something Else')).toBe(false);
       expect(isBudgetPlanningLine('')).toBe(false);
+    });
+  });
+
+  describe('decodeBCEnum', () => {
+    it('decodes the "G/L Account" type encoded by BC as "G_x002F_L_x0020_Account"', () => {
+      // Confirmed against the live /jobPlanningLines response for PR00100 task 9999.
+      expect(decodeBCEnum('G_x002F_L_x0020_Account')).toBe('G/L Account');
+    });
+
+    it('decodes the "Both Budget and Billable" lineType', () => {
+      expect(decodeBCEnum('Both_x0020_Budget_x0020_and_x0020_Billable')).toBe(
+        'Both Budget and Billable'
+      );
+    });
+
+    it('leaves already-plain values unchanged', () => {
+      expect(decodeBCEnum('Resource')).toBe('Resource');
+      expect(decodeBCEnum('Budget')).toBe('Budget');
+      expect(decodeBCEnum('G/L Account')).toBe('G/L Account');
+    });
+
+    it('returns an empty string for undefined or empty input', () => {
+      expect(decodeBCEnum(undefined)).toBe('');
+      expect(decodeBCEnum('')).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

Job Planning Lines of **Type = G/L Account** were not appearing in the **Budget Cost** and **Billable Price** per-type breakdowns on the project details page — the G/L Account row always showed £0.

**Root cause:** BC's OData serializer URL-encodes named enum values, so `type` "G/L Account" arrives over the wire as `G_x002F_L_x0020_Account` (`/` → `_x002F_`, space → `_x0020_`). Thyme compared the raw value against the plain `'G/L Account'` string, so these lines never matched. (The same encoding was already handled for `lineType` but not for `type`.)

Confirmed against **live production BC** — `/jobPlanningLines` for PR00100 task 9999 returns:

```json
{ "lineType": "Budget",   "type": "G_x002F_L_x0020_Account", "totalCost": 500 }
{ "lineType": "Billable", "type": "G_x002F_L_x0020_Account", "totalPrice": 24000 }
```
<img width="1311" height="686" alt="image" src="https://github.com/user-attachments/assets/e7546ef8-0358-4002-a48b-77c069708694" />


## Changes

- **`src/utils/unitConversion.ts`** — add `decodeBCEnum()`, which generically decodes BC's `_xHHHH_` enum escapes (not hardcoded to one value — decodes whatever BC sends).
- **`src/services/bc/bcClient.ts`** — decode `type` and `lineType` once at the fetch boundary (`getJobPlanningLines` and `getJobPlanningLinesForWeek`), so all downstream comparisons use the plain values.
- **`tests/unit/utils/unitConversion.test.ts`** — 4 new tests covering the exact wire value confirmed from production.

## Test plan

- [x] Confirmed root cause against live production BC (`/jobPlanningLines`, PR00100 task 9999)
- [x] `bun run test` — 37/37 unit tests pass (incl. new `decodeBCEnum` cases)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] Manually verified on project PR00100: Budget Cost G/L Account row now shows **£500.00** and Billable Price G/L Account row shows **£24,000.00** (previously £0.00)

> Note: `bun run format:check` flags ~161 files locally due to a Windows CRLF/line-ending mismatch (pristine `main` files I never touched also fail). The committed blobs are LF (`core.autocrlf=true`), so CI's format check passes.

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)