### PR TITLE
feat: create a missing timesheet from Thyme instead of asking a manager

### DIFF
--- a/src/components/timesheet/TeammateSelector.tsx
+++ b/src/components/timesheet/TeammateSelector.tsx
@@ -11,7 +11,7 @@ import {
 import { useTeammateStore, useCompanyStore } from '@/hooks';
 import { useAuth } from '@/services/auth';
 import { cn } from '@/utils';
-import type { BCEmployee } from '@/types';
+import type { Teammate } from '@/types';
 
 export function TeammateSelector() {
   const [isOpen, setIsOpen] = useState(false);
@@ -25,8 +25,8 @@ export function TeammateSelector() {
 
   // Fetch teammates on mount and when company changes
   useEffect(() => {
-    fetchTeammates();
-  }, [fetchTeammates, selectedCompany]);
+    fetchTeammates(account?.username);
+  }, [fetchTeammates, selectedCompany, account?.username]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -52,7 +52,7 @@ export function TeammateSelector() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen]);
 
-  const handleSelect = (teammate: BCEmployee | null) => {
+  const handleSelect = (teammate: Teammate | null) => {
     selectTeammate(teammate);
     setIsOpen(false);
     setSearchQuery('');
@@ -70,19 +70,19 @@ export function TeammateSelector() {
     return true;
   });
 
-  // Separate current user from other teammates
+  // Separate current user from other teammates. isCurrentUser comes from matching the
+  // signed-in user to a BC resource; the email comparison is a fallback for when the
+  // resource could not be resolved.
   const currentUserEmail = account?.username?.toLowerCase();
-  const currentUserTeammate = filteredTeammates.find(
-    (t) => t.email?.toLowerCase() === currentUserEmail
-  );
-  const otherTeammates = filteredTeammates.filter(
-    (t) => t.email?.toLowerCase() !== currentUserEmail
-  );
+  const isCurrentUser = (t: Teammate) =>
+    t.isCurrentUser || (!!t.email && t.email.toLowerCase() === currentUserEmail);
+  const currentUserTeammate = filteredTeammates.find(isCurrentUser);
+  const otherTeammates = filteredTeammates.filter((t) => !isCurrentUser(t));
 
-  // Don't show if no teammates available (only self)
-  if (teammates.length <= 1 && !isLoading) {
-    return null;
-  }
+  // Shown even when there is nobody else, so the capability is discoverable rather
+  // than silently absent - disabled with a reason instead of hidden.
+  const hasOthers = teammates.some((t) => !isCurrentUser(t));
+  const isDisabled = !isLoading && !hasOthers;
 
   const displayName = selectedTeammate ? selectedTeammate.displayName : 'My Timesheet';
 
@@ -90,14 +90,21 @@ export function TeammateSelector() {
     <div className="relative" ref={dropdownRef}>
       {/* Trigger Button */}
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => !isDisabled && setIsOpen(!isOpen)}
+        disabled={isDisabled}
         className={cn(
           'flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors',
-          'border-dark-600 bg-dark-800 hover:border-dark-500 hover:bg-dark-700 border',
+          'border-dark-600 bg-dark-800 border',
+          !isDisabled && 'hover:border-dark-500 hover:bg-dark-700',
+          isDisabled && 'cursor-not-allowed opacity-50',
           isOpen && 'border-knowall-green bg-dark-700',
           selectedTeammate && 'border-thyme-600'
         )}
-        title="View teammate timesheets"
+        title={
+          isDisabled
+            ? 'You are the only person set up for timesheets in this company'
+            : "View and create your team's timesheets"
+        }
         aria-expanded={isOpen}
         aria-haspopup="listbox"
       >
@@ -117,7 +124,9 @@ export function TeammateSelector() {
           {/* Header */}
           <div className="border-dark-600 border-b px-4 py-3">
             <h3 className="text-sm font-medium text-white">Teammates</h3>
-            <p className="text-dark-400 mt-0.5 text-xs">View your team&apos;s timesheets</p>
+            <p className="text-dark-400 mt-0.5 text-xs">
+              View and create your team&apos;s timesheets
+            </p>
           </div>
 
           {/* Search */}

--- a/src/components/timesheet/WeeklyTimesheet.tsx
+++ b/src/components/timesheet/WeeklyTimesheet.tsx
@@ -87,8 +87,18 @@ export function WeeklyTimesheet() {
   const handleCreateTimesheet = async () => {
     setIsCreatingTimesheet(true);
     try {
-      await createTimesheet(userEmail);
-      toast.success('Timesheet created');
+      await createTimesheet();
+      toast.success(
+        selectedTeammate
+          ? `Timesheet created for ${selectedTeammate.displayName}`
+          : 'Timesheet created'
+      );
+      // Re-read whichever timesheet is on screen so the new one becomes current
+      if (selectedTeammate) {
+        await fetchTeammateEntries(selectedTeammate, currentWeekStart);
+      } else {
+        await fetchWeekEntries(userEmail, currentWeekStart);
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to create timesheet');
     } finally {
@@ -370,7 +380,7 @@ Thank you!`)}`}
   }
 
   // No timesheet exists state
-  if (noTimesheetExists && !isViewingTeammate) {
+  if (noTimesheetExists) {
     const weekStartStr = format(currentWeekStart, 'MMM d');
     const weekEndStr = format(
       new Date(currentWeekStart.getTime() + 6 * 24 * 60 * 60 * 1000),
@@ -380,7 +390,8 @@ Thank you!`)}`}
 
     return (
       <div className="space-y-6">
-        {/* Header */}
+        {/* Header - the teammate selector lives in the page header above, and stays
+            usable here so a missing timesheet can be created for a colleague */}
         <div className="flex items-center justify-between">
           <WeekNavigation
             currentWeekStart={currentWeekStart}
@@ -397,14 +408,19 @@ Thank you!`)}`}
             <ExclamationTriangleIcon className="mb-4 h-12 w-12 text-yellow-500" />
             <h3 className="mb-2 text-lg font-semibold text-white">No Timesheet Available</h3>
             <p className="text-dark-300 mb-4 max-w-md">
-              There is no timesheet created for the week of {weekStartStr} - {weekEndStr}. A
-              timesheet must be created before you can enter time.
+              There is no timesheet created for{' '}
+              {selectedTeammate ? selectedTeammate.displayName : 'you'} for the week of{' '}
+              {weekStartStr} - {weekEndStr}. A timesheet must be created before time can be entered.
             </p>
 
             {missingTimesheetResourceNo && (
               <div className="mb-6 flex flex-col items-center">
                 <Button onClick={handleCreateTimesheet} disabled={isCreatingTimesheet}>
-                  {isCreatingTimesheet ? 'Creating...' : 'Create timesheet'}
+                  {isCreatingTimesheet
+                    ? 'Creating...'
+                    : selectedTeammate
+                      ? `Create timesheet for ${selectedTeammate.displayName}`
+                      : 'Create timesheet'}
                 </Button>
                 <p className="text-dark-400 mt-2 text-xs">
                   Creates it in Business Central for resource {missingTimesheetResourceNo}

--- a/src/components/timesheet/WeeklyTimesheet.tsx
+++ b/src/components/timesheet/WeeklyTimesheet.tsx
@@ -54,6 +54,8 @@ export function WeeklyTimesheet() {
     noTimesheetExists,
     noResourceExists,
     extensionNotInstalled,
+    missingTimesheetResourceNo,
+    createTimesheet,
     fetchWeekEntries,
     fetchTeammateEntries,
     navigateToWeek,
@@ -80,6 +82,19 @@ export function WeeklyTimesheet() {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedEntry, setSelectedEntry] = useState<TimeEntry | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCreatingTimesheet, setIsCreatingTimesheet] = useState(false);
+
+  const handleCreateTimesheet = async () => {
+    setIsCreatingTimesheet(true);
+    try {
+      await createTimesheet(userEmail);
+      toast.success('Timesheet created');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create timesheet');
+    } finally {
+      setIsCreatingTimesheet(false);
+    }
+  };
 
   // Pick a random quote on mount
   const quote = useMemo(() => getRandomQuote(), []);
@@ -386,9 +401,20 @@ Thank you!`)}`}
               timesheet must be created before you can enter time.
             </p>
 
+            {missingTimesheetResourceNo && (
+              <div className="mb-6 flex flex-col items-center">
+                <Button onClick={handleCreateTimesheet} disabled={isCreatingTimesheet}>
+                  {isCreatingTimesheet ? 'Creating...' : 'Create timesheet'}
+                </Button>
+                <p className="text-dark-400 mt-2 text-xs">
+                  Creates it in Business Central for resource {missingTimesheetResourceNo}
+                </p>
+              </div>
+            )}
+
             <div className="max-w-lg text-left">
               <p className="text-dark-300 mb-2 text-sm font-medium">
-                To resolve this, ask your timesheet manager to:
+                Or create it manually in Business Central:
               </p>
               <ol className="text-dark-400 list-inside list-decimal space-y-2 text-sm">
                 <li>

--- a/src/hooks/useTeammateStore.ts
+++ b/src/hooks/useTeammateStore.ts
@@ -1,17 +1,31 @@
 import { create } from 'zustand';
-import type { BCEmployee } from '@/types';
+import type { BCEmployee, BCResource, Teammate } from '@/types';
 import { bcClient } from '@/services/bc/bcClient';
 
 interface TeammateStore {
-  teammates: BCEmployee[];
-  selectedTeammate: BCEmployee | null;
+  teammates: Teammate[];
+  selectedTeammate: Teammate | null;
   isLoading: boolean;
   error: string | null;
 
-  fetchTeammates: () => Promise<void>;
-  selectTeammate: (teammate: BCEmployee | null) => void;
+  fetchTeammates: (currentUserEmail?: string) => Promise<void>;
+  selectTeammate: (teammate: Teammate | null) => void;
   clearSelection: () => void;
   isViewingTeammate: () => boolean;
+}
+
+/**
+ * Employee records carry the nicer display data (job title, email) but are optional
+ * in BC - a company can run timesheets with resources alone. Match on name so the
+ * extra detail is used where it exists, without the list depending on it.
+ */
+function findMatchingEmployee(
+  resource: BCResource,
+  employees: BCEmployee[]
+): BCEmployee | undefined {
+  const resourceName = (resource.name || resource.displayName || '').trim().toLowerCase();
+  if (!resourceName) return undefined;
+  return employees.find((e) => e.displayName?.trim().toLowerCase() === resourceName);
 }
 
 export const useTeammateStore = create<TeammateStore>((set, get) => ({
@@ -20,18 +34,51 @@ export const useTeammateStore = create<TeammateStore>((set, get) => ({
   isLoading: false,
   error: null,
 
-  fetchTeammates: async () => {
+  fetchTeammates: async (currentUserEmail?: string) => {
     set({ isLoading: true, error: null });
     try {
-      const employees = await bcClient.getEmployees("status eq 'Active'");
-      set({ teammates: employees, isLoading: false });
+      // Sourced from resources, not employees: timesheets are keyed on the resource,
+      // and a company can have resources set up for time tracking with no employee
+      // records at all. Only resources flagged for time sheets can have one, so
+      // anything else would just be a dead entry in the list.
+      const [resources, employees] = await Promise.all([
+        bcClient.getResources('useTimeSheet eq true'),
+        bcClient.getEmployees("status eq 'Active'").catch(() => [] as BCEmployee[]),
+      ]);
+
+      let currentUserResourceNo: string | undefined;
+      if (currentUserEmail) {
+        try {
+          const resource = await bcClient.getResourceByEmail(currentUserEmail);
+          currentUserResourceNo = resource?.number;
+        } catch {
+          // Falling back to no current-user marker is fine; the list still works
+        }
+      }
+
+      const teammates: Teammate[] = resources.map((resource) => {
+        const employee = findMatchingEmployee(resource, employees);
+        return {
+          id: resource.id,
+          resourceNo: resource.number,
+          displayName: resource.name || resource.displayName || resource.number,
+          givenName: employee?.givenName,
+          surname: employee?.surname,
+          jobTitle: employee?.jobTitle,
+          email: employee?.email,
+          isCurrentUser: resource.number === currentUserResourceNo,
+        };
+      });
+
+      teammates.sort((a, b) => a.displayName.localeCompare(b.displayName));
+      set({ teammates, isLoading: false });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to fetch teammates';
       set({ error: message, isLoading: false, teammates: [] });
     }
   },
 
-  selectTeammate: (teammate: BCEmployee | null) => {
+  selectTeammate: (teammate: Teammate | null) => {
     set({ selectedTeammate: teammate });
   },
 

--- a/src/hooks/useTimeEntriesStore.ts
+++ b/src/hooks/useTimeEntriesStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { TimeEntry, WeekData, BCEmployee, BCTimeSheet, TimesheetDisplayStatus } from '@/types';
+import type { TimeEntry, WeekData, Teammate, BCTimeSheet, TimesheetDisplayStatus } from '@/types';
 import {
   timeEntryService,
   NoResourceError,
@@ -29,7 +29,7 @@ interface TimeEntriesStore {
 
   // Entry operations
   fetchWeekEntries: (userId: string, weekStart?: Date) => Promise<void>;
-  fetchTeammateEntries: (teammate: BCEmployee, weekStart?: Date) => Promise<void>;
+  fetchTeammateEntries: (teammate: Teammate, weekStart?: Date) => Promise<void>;
   addEntry: (
     entry: Omit<
       TimeEntry,
@@ -48,7 +48,7 @@ interface TimeEntriesStore {
   goToDate: (date: Date) => void;
 
   // Timesheet operations
-  createTimesheet: (userId: string) => Promise<void>;
+  createTimesheet: () => Promise<void>;
   submitTimesheet: () => Promise<void>;
   reopenTimesheet: () => Promise<void>;
   isTimesheetEditable: () => boolean;
@@ -143,14 +143,30 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
     }
   },
 
-  fetchTeammateEntries: async (teammate: BCEmployee, weekStart?: Date) => {
+  fetchTeammateEntries: async (teammate: Teammate, weekStart?: Date) => {
     const week = weekStart || get().currentWeekStart;
-    set({ isLoading: true, error: null, currentWeekStart: week });
+    set({
+      isLoading: true,
+      error: null,
+      currentWeekStart: week,
+      noTimesheetExists: false,
+      missingTimesheetResourceNo: null,
+    });
 
     try {
       const entries = await timeEntryService.getTeammateEntries(week, teammate);
       set({ entries, isLoading: false });
     } catch (error) {
+      if (error instanceof NoTimesheetError) {
+        set({
+          entries: [],
+          noTimesheetExists: true,
+          missingTimesheetResourceNo: error.resourceNo,
+          isLoading: false,
+          error: error.message,
+        });
+        return;
+      }
       const message = error instanceof Error ? error.message : 'Failed to fetch teammate entries';
       set({ error: message, isLoading: false });
     }
@@ -295,7 +311,9 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
     set({ currentWeekStart: getWeekStart(date) });
   },
 
-  createTimesheet: async (userId: string) => {
+  // Creates the timesheet only. The caller re-reads the week afterwards, since whether
+  // that means your own timesheet or a teammate's depends on what is being viewed.
+  createTimesheet: async () => {
     const resourceNo = get().missingTimesheetResourceNo;
     if (!resourceNo) {
       throw new Error('No resource is available to create a timesheet for');
@@ -305,9 +323,7 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
     try {
       set({ isLoading: true, error: null });
       await bcClient.createTimeSheet(resourceNo, format(week, 'yyyy-MM-dd'));
-      set({ missingTimesheetResourceNo: null });
-      // Re-read the week so the newly created timesheet becomes the current one
-      await get().fetchWeekEntries(userId, week);
+      set({ missingTimesheetResourceNo: null, noTimesheetExists: false });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create timesheet';
       set({ error: message, isLoading: false });

--- a/src/hooks/useTimeEntriesStore.ts
+++ b/src/hooks/useTimeEntriesStore.ts
@@ -9,6 +9,7 @@ import {
   bcClient,
 } from '@/services/bc';
 import { getWeekStart, getWeekEnd } from '@/utils';
+import { format } from 'date-fns';
 
 interface TimeEntriesStore {
   entries: TimeEntry[];
@@ -23,6 +24,8 @@ interface TimeEntriesStore {
   noResourceExists: boolean;
   extensionNotInstalled: boolean;
   userEmail: string | null;
+  // Resource the missing timesheet would belong to, so it can be created from the UI
+  missingTimesheetResourceNo: string | null;
 
   // Entry operations
   fetchWeekEntries: (userId: string, weekStart?: Date) => Promise<void>;
@@ -45,6 +48,7 @@ interface TimeEntriesStore {
   goToDate: (date: Date) => void;
 
   // Timesheet operations
+  createTimesheet: (userId: string) => Promise<void>;
   submitTimesheet: () => Promise<void>;
   reopenTimesheet: () => Promise<void>;
   isTimesheetEditable: () => boolean;
@@ -69,6 +73,7 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
   noResourceExists: false,
   extensionNotInstalled: false,
   userEmail: null,
+  missingTimesheetResourceNo: null,
 
   fetchWeekEntries: async (userId: string, weekStart?: Date) => {
     const week = weekStart || get().currentWeekStart;
@@ -127,6 +132,7 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
           noTimesheetExists: true,
           noResourceExists: false,
           extensionNotInstalled: false,
+          missingTimesheetResourceNo: error.resourceNo,
           isLoading: false,
           error: error.message,
         });
@@ -287,6 +293,26 @@ export const useTimeEntriesStore = create<TimeEntriesStore>((set, get) => ({
 
   goToDate: (date: Date) => {
     set({ currentWeekStart: getWeekStart(date) });
+  },
+
+  createTimesheet: async (userId: string) => {
+    const resourceNo = get().missingTimesheetResourceNo;
+    if (!resourceNo) {
+      throw new Error('No resource is available to create a timesheet for');
+    }
+
+    const week = get().currentWeekStart;
+    try {
+      set({ isLoading: true, error: null });
+      await bcClient.createTimeSheet(resourceNo, format(week, 'yyyy-MM-dd'));
+      set({ missingTimesheetResourceNo: null });
+      // Re-read the week so the newly created timesheet becomes the current one
+      await get().fetchWeekEntries(userId, week);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create timesheet';
+      set({ error: message, isLoading: false });
+      throw error;
+    }
   },
 
   submitTimesheet: async () => {

--- a/src/services/bc/timeEntryService.ts
+++ b/src/services/bc/timeEntryService.ts
@@ -35,11 +35,14 @@ export class ExtensionNotInstalledError extends Error {
 
 // Error thrown when no timesheet exists for the user/week
 export class NoTimesheetError extends Error {
+  resourceNo: string;
+
   constructor(resourceNo: string, weekStart: Date) {
     super(
       `No timesheet exists for resource ${resourceNo} for week starting ${format(weekStart, 'yyyy-MM-dd')}. Please contact your manager to create one.`
     );
     this.name = 'NoTimesheetError';
+    this.resourceNo = resourceNo;
   }
 }
 

--- a/src/services/bc/timeEntryService.ts
+++ b/src/services/bc/timeEntryService.ts
@@ -1,12 +1,6 @@
 import toast from 'react-hot-toast';
 import { bcClient } from './bcClient';
-import type {
-  TimeEntry,
-  BCTimeSheet,
-  BCTimeSheetLine,
-  BCTimeSheetDetail,
-  BCEmployee,
-} from '@/types';
+import type { TimeEntry, BCTimeSheet, BCTimeSheetLine, BCTimeSheetDetail, Teammate } from '@/types';
 import { format, startOfWeek } from 'date-fns';
 
 // Error thrown when no resource record exists in BC for the user
@@ -663,16 +657,9 @@ export const timeEntryService = {
   /**
    * Get entries for a teammate from Business Central.
    */
-  async getTeammateEntries(weekStart: Date, teammate: BCEmployee): Promise<TimeEntry[]> {
+  async getTeammateEntries(weekStart: Date, teammate: Teammate): Promise<TimeEntry[]> {
     try {
-      // Get resource by employee email
-      const resource = teammate.email ? await bcClient.getResourceByEmail(teammate.email) : null;
-
-      if (!resource) {
-        return [];
-      }
-
-      const timesheet = await this.getTimesheet(resource.number, weekStart);
+      const timesheet = await this.getTimesheet(teammate.resourceNo, weekStart);
       const [lines, details] = await Promise.all([
         bcClient.getTimeSheetLines(timesheet.number),
         bcClient.getAllTimeSheetDetails(timesheet.number),
@@ -680,13 +667,18 @@ export const timeEntryService = {
 
       return bcDataToTimeEntries(lines, details, timesheet, teammate.id);
     } catch (error) {
+      // A missing timesheet is actionable - the caller can offer to create one - so
+      // it travels up rather than being flattened into an empty week like the rest.
+      if (error instanceof NoTimesheetError) {
+        throw error;
+      }
       // Log error for debugging but don't expose to user
-      // This can fail for various reasons: no timesheet, no resource, network issues
+      // This can fail for various reasons: no resource, network issues
       if (process.env.NODE_ENV === 'development') {
         console.error('Failed to get teammate entries:', {
           weekStart,
           teammateId: teammate.id,
-          teammateEmail: teammate.email,
+          teammateResourceNo: teammate.resourceNo,
           error,
         });
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,22 @@ export interface BCEmployee {
   lastModifiedDateTime?: string;
 }
 
+/**
+ * A person whose timesheet can be viewed. Sourced from BC resources rather than
+ * employees, because timesheets are keyed on the resource - a company can have
+ * resources set up for time tracking and no employee records at all.
+ */
+export interface Teammate {
+  id: string;
+  resourceNo: string;
+  displayName: string;
+  givenName?: string;
+  surname?: string;
+  jobTitle?: string;
+  email?: string;
+  isCurrentUser?: boolean;
+}
+
 export interface BCJobTask {
   id: string;
   jobNo: string;


### PR DESCRIPTION
Fixes #216

## Problem

The **No Timesheet Available** screen was a dead end. It told you to open Business Central, run *Create Time Sheets*, or email someone who would — for a week you cannot log time against until someone does.

Separately, the teammate picker was built from `/employees`, but timesheets are keyed on **resources**. A company can run time tracking with resources and no employee records at all — KnowAll AI SAS de CV does exactly that — so the list came back empty and `TeammateSelector.tsx:83` hid the control entirely.

## Change

**Create a timesheet from Thyme**
- A **Create timesheet** button on the No Timesheet screen, sitting beside **Email request to manager** so both routes are at the decision point. The manual BC steps remain below as a last resort.
- `NoTimesheetError` now carries the `resourceNo` it failed on; the store keeps it as `missingTimesheetResourceNo`.
- After creating, the week is re-read so the new timesheet becomes current and the grid appears — no refresh.

**Teammates sourced from resources**
- The list now comes from resources flagged for time sheets. Employees are used only to enrich the display with job title and email where a matching record exists.
- `Teammate` carries `resourceNo`, which removes the email lookup that stood between a teammate and their timesheet.
- The selector stays visible when you are the only person, disabled with a reason, rather than vanishing.
- The No Timesheet screen now also renders when viewing a teammate, so a missing week can be created **for a colleague**.

No client-side permission check: BC enforces who may act for whom, and duplicating that here would only drift from it.

## Depends on

knowall-ai/thyme-bc-extension#39 — **deployed to Production as v1.11.0.0**. Against the previous extension the POST produced an unusable record.

## Test plan

1. Open a week with no timesheet, e.g. `/time?week=2026-07-27`. Expect **No Timesheet Available** with a **Create timesheet** button beside **Email request to manager**, and the resource number named beneath.
2. Click **Create timesheet**. Expect a success toast and the timesheet grid to appear immediately, with no manual refresh.
3. Confirm in Business Central that the new Time Sheet Header has a real `No.` from the number series and an `Ending Date` six days after the start.
4. Open the teammate dropdown. Expect colleagues set up for time sheets to be listed, including any who have a resource but no employee record.
5. Select a colleague and navigate to a week where they have no timesheet. Expect the same screen with **Create timesheet for &lt;name&gt;**, and the button to create it against *their* resource.
6. In a company where you are the only person set up for time sheets, expect the dropdown to be visible but greyed out, with a tooltip explaining why.

Verified locally: `bun run typecheck` clean, `bun run build` succeeds, 54/54 unit tests pass, `bun run lint` 0 errors. Steps 1-5 exercised by hand against a running dev server; the underlying API was tested separately in the BC Sandbox (9/9 cases, including the rejection paths).
